### PR TITLE
feat(api): Add template search and filtering endpoint (#109)

### DIFF
--- a/resume-api/api/routes.py
+++ b/resume-api/api/routes.py
@@ -214,22 +214,54 @@ async def tailor_resume(request: Request, body: TailorRequest, auth: AuthorizedA
     tags=["Variants"],
 )
 @rate_limit(settings.rate_limit_variants)
-async def list_variants(request: Request):
+async def list_variants(
+    request: Request,
+    search: str = None,
+    tags: str = None,
+    category: str = None,
+    industry: str = None,
+    layout: str = None,
+    color_theme: str = None,
+):
     """
-    List all available resume template variants.
+    List or filter resume template variants.
 
     Rate limit: 60 requests per minute per API key.
+    
+    Query Parameters:
+    - search: Search query for name/description
+    - tags: Comma-separated list of tags (e.g., "modern,professional")
+    - category: Template category (e.g., "technical", "creative")
+    - industry: Industry filter (e.g., "technology", "finance")
+    - layout: Layout type ("single-column", "double-column")
+    - color_theme: Color theme
 
     Returns:
-        VariantsResponse with list of available variants
+        VariantsResponse with list of available (or filtered) variants
     """
     try:
-        variants = variant_manager.list_variants()
-
-        variant_metadata = []
-        for variant in variants:
-            metadata = variant_manager.get_variant_metadata(variant)
-            variant_metadata.append(VariantMetadata(**metadata))
+        # Parse tags from comma-separated string
+        tags_list = None
+        if tags:
+            tags_list = [t.strip() for t in tags.split(",") if t.strip()]
+        
+        # Use filter if any filter params provided, otherwise get all with metadata
+        if any([search, tags_list, category, industry, layout, color_theme]):
+            filtered_variants = variant_manager.filter_variants(
+                search=search,
+                tags=tags_list,
+                category=category,
+                industry=industry,
+                layout=layout,
+                color_theme=color_theme,
+            )
+            variant_metadata = [VariantMetadata(**v) for v in filtered_variants]
+        else:
+            variants = variant_manager.list_variants()
+            variant_metadata = []
+            for variant in variants:
+                metadata = variant_manager.get_variant_metadata(variant)
+                variant_metadata.append(VariantMetadata(**metadata))
 
         return VariantsResponse(variants=variant_metadata)
 

--- a/resume-api/lib/cli/variants.py
+++ b/resume-api/lib/cli/variants.py
@@ -148,6 +148,84 @@ class VariantManager:
 
         return result
 
+    def filter_variants(
+        self,
+        search: str = None,
+        tags: List[str] = None,
+        category: str = None,
+        industry: str = None,
+        layout: str = None,
+        color_theme: str = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Filter variants based on search criteria.
+        
+        Args:
+            search: Search query for name/description
+            tags: Comma-separated list of tags
+            category: Template category
+            industry: Industry filter
+            layout: Layout type (single-column, double-column)
+            color_theme: Color theme
+            
+        Returns:
+            List of filtered variants with metadata
+        """
+        variants = self.get_variants_with_metadata()
+        
+        filtered = []
+        
+        for variant in variants:
+            # Search filter
+            if search:
+                search_lower = search.lower()
+                name = variant.get("name", "").lower()
+                display_name = variant.get("display_name", "").lower()
+                description = variant.get("description", "").lower()
+                
+                if not (search_lower in name or 
+                        search_lower in display_name or 
+                        search_lower in description):
+                    continue
+            
+            # Tags filter
+            if tags:
+                variant_tags = variant.get("tags", [])
+                if isinstance(variant_tags, str):
+                    variant_tags = [t.strip() for t in variant_tags.split(",")]
+                
+                if not any(tag.lower() in [t.lower() for t in variant_tags] for tag in tags):
+                    continue
+            
+            # Category filter
+            if category:
+                variant_category = variant.get("category", "").lower()
+                if variant_category != category.lower():
+                    continue
+            
+            # Industry filter
+            if industry:
+                variant_industry = variant.get("industry", "").lower()
+                if variant_industry != industry.lower():
+                    continue
+            
+            # Layout filter
+            if layout:
+                variant_layout = variant.get("layout", "").lower()
+                if variant_layout != layout.lower():
+                    continue
+            
+            # Color theme filter
+            if color_theme:
+                variant_color = variant.get("color_theme", "").lower()
+                if variant_color != color_theme.lower():
+                    continue
+            
+            filtered.append(variant)
+        
+        logger.info(f"Filtered {len(variants)} variants down to {len(filtered)}")
+        return filtered
+
 
 # Mock version for testing
 class MockVariantManager:


### PR DESCRIPTION
## Summary

Implements Issue #109: Template Search and Filtering endpoint for advanced template filtering.

## Changes

### Backend
- Added `filter_variants` method to `VariantManager` class in `resume-api/lib/cli/variants.py`
- Updated GET `/v1/variants` endpoint with new query parameters:
  - `search`: Search query for name/description
  - `tags`: Comma-separated list of tags (e.g., "modern,professional")
  - `category`: Template category (e.g., "technical", "creative")
  - `industry`: Industry filter (e.g., "technology", "finance")
  - `layout`: Layout type ("single-column", "double-column")
  - `color_theme`: Color theme
- Filters work with template metadata stored in metadata.yaml files
- Backward compatible - returns all variants if no filters specified

## API Endpoint

\`\`\`
GET /v1/variants?search=modern&tags=professional,technical&category=technical
\`\`\`

## Usage Examples

- Search by name: `GET /v1/variants?search=modern`
- Filter by tags: `GET /v1/variants?tags=professional`
- Filter by category: `GET /v1/variants?category=technical`
- Combine filters: `GET /v1/variants?search=pro&tags=modern&layout=single-column`

## Testing

- Test various filter combinations
- Test search functionality
- Test backward compatibility (no filters returns all variants)

## References

- Issue #109: https://github.com/anchapin/ResumeAI/issues/109
- ADVANCED_FEATURES.md - Advanced Template Search and Filtering