### PR TITLE
[Cleanup] Add dist/, coverage/, and *.backup to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ dist-ssr
 # Python
 __pycache__/
 *.pyc
+
+# Build outputs and coverage
+dist/
+coverage/
+
+# Backup files
+*.backup


### PR DESCRIPTION
## Summary
The repository contains build artifacts that should be ignored:
- \`dist/\` folder (Vite build output)
- \`coverage/\` folder (test coverage reports)
- \`*.backup\` files (backup files)

## Changes Made
Added the following to \`.gitignore\`:
- \`dist/\`
- \`coverage/\`
- \`*.backup\`

## Tasks
- [x] Add \`dist/\`, \`coverage/\`, \`*.backup\` to \`.gitignore\`

Closes #135