### PR TITLE
Clarify Python version: use 3.11 or 3.12, not 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For detailed architecture documentation, see [CLAUDE.md](CLAUDE.md).
 Before running ResumeAI, ensure you have the following installed:
 
 - **Node.js** (v18+) - [Download](https://nodejs.org/)
-- **Python** (v3.11+) - [Download](https://www.python.org/)
+- **Python**: 3.11 or 3.12 (Python 3.14 is NOT supported due to PyMuPDF compatibility)
 - **LaTeX** - Required for PDF generation
   - macOS: `brew install texlive`
   - Ubuntu: `sudo apt-get install texlive-latex-base`


### PR DESCRIPTION
## Summary

This PR clarifies the Python version requirement in the README. Python 3.14 is NOT supported due to PyMuPDF compatibility issues.

## Changes

- Updated README.md to explicitly specify Python 3.11 or 3.12 instead of just "v3.11+"
- Added note about Python 3.14 not being supported

## Why

PyMuPDF (a dependency used for PDF generation) does not support Python 3.14. This change makes the requirements clear to prevent users from trying to use Python 3.14.