### PR TITLE
Fix: Replace PyMuPDF with pypdf for Python 3.14 compatibility (Issue #201)

### DIFF
--- a/resume-api/api/routes.py
+++ b/resume-api/api/routes.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from docx import Document
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 import httpx  # HTTP client for LinkedIn API
-import fitz  # PyMuPDF for PDF parsing
+from pypdf import PdfReader  # pypdf for PDF parsing (Python 3.14 compatible)
 
 from .models import (
     ResumeRequest,
@@ -541,18 +541,16 @@ def extract_text_from_pdf(file_bytes: bytes) -> str:
         ValueError: If PDF is corrupted or invalid
     """
     try:
-        doc = fitz.open(stream=file_bytes, doc_type="pdf")
+        # Use pypdf (Python 3.14 compatible alternative to PyMuPDF)
+        reader = PdfReader(io.BytesIO(file_bytes))
     except Exception as e:
         raise ValueError(f"Invalid or corrupted PDF file: {str(e)}")
 
     text_parts = []
-    for page_num in range(len(doc)):
-        page = doc[page_num]
-        text = page.get_text()
-        if text.strip():
-            text_parts.append(text)
-
-    doc.close()
+    for page in reader.pages:
+        text = page.extract_text()
+        if text and text.strip():
+            text_parts.append(text.strip())
 
     if not text_parts:
         raise ValueError("No text content found in PDF. This may be a scanned image.")

--- a/resume-api/requirements.txt
+++ b/resume-api/requirements.txt
@@ -67,4 +67,5 @@ sqlalchemy==2.0.36
 aiosqlite==0.20.0
 
 # PDF Parsing (for import feature)
-pymupdf>=1.24.0
+# Using pypdf instead of pymupdf for better Python 3.14 compatibility
+pypdf>=4.0.0


### PR DESCRIPTION
## Summary

This PR fixes issue #201 where the ResumeAI backend fails to start due to missing PyMuPDF dependency.

## Changes

- Replaced `pymupdf>=1.24.0` with `pypdf>=4.0.0` in requirements.txt
- Updated `routes.py` to use `pypdf.PdfReader` instead of PyMuPDF's `fitz`
- Updated `extract_text_from_pdf` function to use pypdf API

## Root Cause

PyMuPDF fails to install on Python 3.14 due to compilation errors. pypdf is a pure Python alternative that is compatible with Python 3.14.

## Testing

The PDF import functionality has been migrated from PyMuPDF to pypdf API.

Closes #201