### PR TITLE
feat: Implement real-time resume preview

### DIFF
--- a/components/ResumePreview.tsx
+++ b/components/ResumePreview.tsx
@@ -1,0 +1,311 @@
+/**
+ * @component ResumePreview
+ * @description Real-time resume preview component that renders resume data as a preview
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { SimpleResumeData } from '../types';
+
+interface ResumePreviewProps {
+  /** The resume data to preview */
+  resumeData: SimpleResumeData;
+  /** Selected template variant */
+  variant?: string;
+  /** Zoom level for the preview (0.5 to 2.0) */
+  zoom?: number;
+  /** Whether to show the preview in split-screen mode */
+  splitMode?: boolean;
+  /** Callback when PDF is requested */
+  onGeneratePDF?: () => void;
+  /** Whether PDF generation is in progress */
+  isGeneratingPDF?: boolean;
+}
+
+/**
+ * ResumePreview component for real-time resume preview
+ * 
+ * @example
+ * ```tsx
+ * <ResumePreview 
+ *   resumeData={resumeData} 
+ *   variant="modern" 
+ *   zoom={1.0}
+ *   splitMode={true}
+ * />
+ * ```
+ */
+const ResumePreview: React.FC<ResumePreviewProps> = ({
+  resumeData,
+  variant = 'modern',
+  zoom = 1.0,
+  splitMode = false,
+  onGeneratePDF,
+  isGeneratingPDF = false,
+}) => {
+  const [previewZoom, setPreviewZoom] = useState(zoom);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Debounced refresh indicator
+  useEffect(() => {
+    setIsRefreshing(true);
+    const timer = setTimeout(() => setIsRefreshing(false), 300);
+    return () => clearTimeout(timer);
+  }, [resumeData]);
+
+  // Format date range
+  const formatDateRange = (start: string, end: string, current?: boolean) => {
+    const startStr = start || '';
+    const endStr = current ? 'Present' : (end || '');
+    if (startStr && endStr) {
+      return `${startStr} - ${endStr}`;
+    }
+    return startStr || endStr;
+  };
+
+  // Memoize the preview content
+  const previewContent = useMemo(() => (
+    <div 
+      className="bg-white shadow-2xl rounded-sm min-h-[1000px] w-full max-w-[800px] mx-auto"
+      style={{ 
+        transform: `scale(${previewZoom})`,
+        transformOrigin: 'top center',
+      }}
+    >
+      {/* Header Section */}
+      <div className="bg-gradient-to-r from-slate-800 to-slate-700 text-white p-8">
+        <h1 className="text-3xl font-bold tracking-tight">
+          {resumeData.name || 'Your Name'}
+        </h1>
+        {resumeData.role && (
+          <p className="text-lg text-slate-300 mt-1 font-medium">
+            {resumeData.role}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-4 mt-4 text-sm text-slate-300">
+          {resumeData.email && (
+            <span className="flex items-center gap-1">
+              <span className="material-symbols-outlined text-base">mail</span>
+              {resumeData.email}
+            </span>
+          )}
+          {resumeData.phone && (
+            <span className="flex items-center gap-1">
+              <span className="material-symbols-outlined text-base">phone</span>
+              {resumeData.phone}
+            </span>
+          )}
+          {resumeData.location && (
+            <span className="flex items-center gap-1">
+              <span className="material-symbols-outlined text-base">location_on</span>
+              {resumeData.location}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Content Section */}
+      <div className="p-8 space-y-6">
+        {/* Summary */}
+        {resumeData.summary && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-800 border-b-2 border-primary-500 pb-1 mb-3">
+              Professional Summary
+            </h2>
+            <p className="text-sm text-slate-600 leading-relaxed">
+              {resumeData.summary}
+            </p>
+          </section>
+        )}
+
+        {/* Experience */}
+        {resumeData.experience.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-800 border-b-2 border-primary-500 pb-1 mb-3">
+              Professional Experience
+            </h2>
+            <div className="space-y-4">
+              {resumeData.experience.map((exp) => (
+                <div key={exp.id} className="border-l-2 border-slate-200 pl-4">
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <h3 className="font-bold text-slate-800">{exp.role}</h3>
+                      <p className="text-sm text-primary-600 font-medium">{exp.company}</p>
+                    </div>
+                    <span className="text-xs text-slate-500 font-medium">
+                      {formatDateRange(exp.startDate, exp.endDate, exp.current)}
+                    </span>
+                  </div>
+                  {exp.description && (
+                    <p className="text-sm text-slate-600 mt-2 leading-relaxed">
+                      {exp.description}
+                    </p>
+                  )}
+                  {exp.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {exp.tags.map((tag, idx) => (
+                        <span 
+                          key={idx}
+                          className="text-xs px-2 py-0.5 bg-slate-100 text-slate-600 rounded"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Skills */}
+        {resumeData.skills.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-800 border-b-2 border-primary-500 pb-1 mb-3">
+              Skills
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {resumeData.skills.map((skill, idx) => (
+                <span 
+                  key={idx}
+                  className="text-sm px-3 py-1 bg-primary-50 text-primary-700 rounded-full font-medium"
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Education */}
+        {resumeData.education && resumeData.education.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-800 border-b-2 border-primary-500 pb-1 mb-3">
+              Education
+            </h2>
+            <div className="space-y-3">
+              {resumeData.education.map((edu) => (
+                <div key={edu.id}>
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <h3 className="font-bold text-slate-800">{edu.institution}</h3>
+                      <p className="text-sm text-slate-600">
+                        {edu.studyType} {edu.area && `in ${edu.area}`}
+                      </p>
+                    </div>
+                    <span className="text-xs text-slate-500 font-medium">
+                      {formatDateRange(edu.startDate, edu.endDate)}
+                    </span>
+                  </div>
+                  {edu.courses && edu.courses.length > 0 && (
+                    <div className="text-xs text-slate-500 mt-1">
+                      Relevant Courses: {edu.courses.slice(0, 5).join(', ')}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Projects */}
+        {resumeData.projects && resumeData.projects.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-800 border-b-2 border-primary-500 pb-1 mb-3">
+              Projects
+            </h2>
+            <div className="space-y-3">
+              {resumeData.projects.map((proj) => (
+                <div key={proj.id}>
+                  <div className="flex justify-between items-start">
+                    <h3 className="font-bold text-slate-800">{proj.name}</h3>
+                    <span className="text-xs text-slate-500 font-medium">
+                      {formatDateRange(proj.startDate, proj.endDate)}
+                    </span>
+                  </div>
+                  {proj.description && (
+                    <p className="text-sm text-slate-600 mt-1">{proj.description}</p>
+                  )}
+                  {proj.url && (
+                    <a 
+                      href={proj.url} 
+                      target="_blank" 
+                      rel="noopener noreferrer"
+                      className="text-xs text-primary-600 hover:underline"
+                    >
+                      {proj.url}
+                    </a>
+                  )}
+                  {proj.roles && proj.roles.length > 0 && (
+                    <div className="text-xs text-slate-500 mt-1">
+                      Roles: {proj.roles.join(', ')}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  ), [resumeData, previewZoom]);
+
+  return (
+    <div className={`flex flex-col h-full ${splitMode ? 'bg-slate-100' : ''}`}>
+      {/* Preview Toolbar */}
+      <div className="flex items-center justify-between px-4 py-2 bg-white border-b border-slate-200 shadow-sm">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-bold text-slate-700">Preview</span>
+          {isRefreshing && (
+            <span className="material-symbols-outlined text-sm text-primary-500 animate-spin">sync</span>
+          )}
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {/* Zoom Controls */}
+          <button
+            onClick={() => setPreviewZoom(Math.max(0.5, previewZoom - 0.1))}
+            className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
+            title="Zoom Out"
+          >
+            <span className="material-symbols-outlined text-lg">remove</span>
+          </button>
+          <span className="text-xs font-medium text-slate-600 min-w-[3rem] text-center">
+            {Math.round(previewZoom * 100)}%
+          </span>
+          <button
+            onClick={() => setPreviewZoom(Math.min(2.0, previewZoom + 0.1))}
+            className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
+            title="Zoom In"
+          >
+            <span className="material-symbols-outlined text-lg">add</span>
+          </button>
+          
+          <div className="h-4 w-px bg-slate-300 mx-2"></div>
+          
+          {/* PDF Download */}
+          {onGeneratePDF && (
+            <button
+              onClick={onGeneratePDF}
+              disabled={isGeneratingPDF}
+              className="flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white text-xs font-bold rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Download PDF"
+            >
+              <span className="material-symbols-outlined text-sm">
+                {isGeneratingPDF ? 'hourglass_empty' : 'download'}
+              </span>
+              {isGeneratingPDF ? 'Generating...' : 'PDF'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Preview Canvas */}
+      <div className="flex-1 overflow-auto p-6 flex justify-center bg-slate-200/50">
+        {previewContent}
+      </div>
+    </div>
+  );
+};
+
+export default ResumePreview;

--- a/pages/Editor.tsx
+++ b/pages/Editor.tsx
@@ -4,6 +4,7 @@ import { convertToAPIData, generatePDF, getVariants, VariantMetadata } from '../
 import { TemplateSelector } from '../components/TemplateSelector';
 import { LinkedInImportDialog } from '../components/LinkedInImportDialog';
 import ExperienceItem from '../components/ExperienceItem';
+import ResumePreview from '../components/ResumePreview';
 
 interface EducationItemProps {
     edu: EducationEntry;
@@ -391,6 +392,9 @@ const Editor: React.FC<EditorProps> = ({ resumeData, onUpdate, onBack, saveStatu
 
   // LinkedIn import state
   const [showLinkedInImport, setShowLinkedInImport] = useState<boolean>(false);
+
+  // Real-time preview state
+  const [showPreview, setShowPreview] = useState<boolean>(false);
 
   // Drag and drop state for section reordering
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
@@ -981,8 +985,9 @@ const Editor: React.FC<EditorProps> = ({ resumeData, onUpdate, onBack, saveStatu
         </div>
       </header>
 
-      <main className="flex-1 flex flex-col items-center w-full">
-        <div className="w-full max-w-[960px] px-6 py-8">
+      <main className={`flex-1 flex w-full ${showPreview ? 'flex-row' : 'flex-col items-center'}`}>
+        {/* Editor Panel */}
+        <div className={`${showPreview ? 'w-1/2 overflow-y-auto' : 'w-full max-w-[960px]'} px-6 py-8`}>
             {/* Header Area */}
             <div className="flex flex-wrap justify-between items-end gap-3 mb-8">
                 <div>
@@ -1025,6 +1030,18 @@ const Editor: React.FC<EditorProps> = ({ resumeData, onUpdate, onBack, saveStatu
                     </p>
                 </div>
                 <div className="flex gap-3">
+                    {/* Preview Toggle Button */}
+                    <button 
+                        onClick={() => setShowPreview(!showPreview)}
+                        className={`flex items-center gap-2 px-4 h-10 rounded-lg border font-bold text-sm transition-colors shadow-sm ${
+                          showPreview 
+                            ? 'bg-primary-600 text-white border-primary-600' 
+                            : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
+                        }`}
+                    >
+                        <span className="material-symbols-outlined text-lg">{showPreview ? 'visibility_off' : 'visibility'}</span>
+                        {showPreview ? 'Hide Preview' : 'Preview'}
+                    </button>
                     <button 
                         onClick={handleGeneratePDF}
                         disabled={isGeneratingPDF}
@@ -1072,6 +1089,19 @@ const Editor: React.FC<EditorProps> = ({ resumeData, onUpdate, onBack, saveStatu
                 </div>
             </div>
         </div>
+
+        {/* Preview Panel */}
+        {showPreview && (
+          <div className="w-1/2 h-[calc(100vh-60px)] sticky top-[60px] border-l border-slate-200">
+            <ResumePreview
+              resumeData={resumeData}
+              variant={selectedVariant}
+              splitMode={true}
+              onGeneratePDF={handleGeneratePDF}
+              isGeneratingPDF={isGeneratingPDF}
+            />
+          </div>
+        )}
       </main>
 
       {/* LinkedIn Import Dialog */}


### PR DESCRIPTION
## Summary
- Add ResumePreview component for live resume rendering
- Implement split-screen layout with editor and preview panels
- Add preview toggle button in editor header
- Support zoom controls and PDF generation from preview
- Auto-refresh preview on resume data changes

## Changes
- \`components/ResumePreview.tsx\`: New component for real-time resume preview
- \`pages/Editor.tsx\`: Updated to include split-screen preview mode

## Testing
1. Open the resume editor
2. Click the 'Preview' button to toggle the preview panel
3. Edit resume data and see changes reflected in real-time
4. Use zoom controls to adjust preview size
5. Generate PDF directly from preview panel

Closes #229