### PR TITLE
fix: Resolve SQLAlchemy foreign key cycle warning

### DIFF
--- a/resume-api/database.py
+++ b/resume-api/database.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     JSON,
     Index,
     Float,
+    ForeignKeyConstraint,
 )
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -64,7 +65,10 @@ class Resume(Base):
     data = Column(JSON, nullable=False)  # Stores resume data as JSON
 
     # Version tracking
-    current_version_id = Column(Integer, ForeignKey("resume_versions.id"))
+    # Note: use_alter=True breaks the circular FK dependency with resume_versions
+    current_version_id = Column(
+        Integer, ForeignKey("resume_versions.id", use_alter=True, name="fk_resume_current_version")
+    )
     current_version = relationship("ResumeVersion", foreign_keys=[current_version_id])
 
     # Sharing settings


### PR DESCRIPTION
## Description
This PR resolves the SQLAlchemy warning about an unresolvable foreign key dependency between tables.

## Problem
There was a circular foreign key dependency between \`resumes\` and \`resume_versions\` tables:
- \`Resume.current_version_id\` → \`resume_versions.id\`
- \`ResumeVersion.resume_id\` → \`resumes.id\`

This caused the warning:
\`\`\`
SAWarning: Can't sort tables for DROP; an unresolvable foreign key dependency exists between tables: resume_versions, resumes; and backend does not support ALTER.
\`\`\`

## Solution
Added \`use_alter=True\` to the \`current_version_id\` ForeignKey in the Resume model. This tells SQLAlchemy to create the foreign key constraint via ALTER TABLE after both tables are created, breaking the circular dependency.

## Changes
- Added \`use_alter=True\` parameter to the ForeignKey
- Added explicit constraint name \`fk_resume_current_version\` for better database management

## Acceptance Criteria
- [x] Warning is resolved
- [x] Database operations work correctly
- [x] All existing tests pass

Closes #265