### PR TITLE
🎨 UX: Enhance ShareDialog accessibility and enable sharing in ResumeManagement

### DIFF
--- a/components/ResumeCard.test.tsx
+++ b/components/ResumeCard.test.tsx
@@ -19,6 +19,7 @@ describe('ResumeCard', () => {
     const onEdit = vi.fn();
     const onDuplicate = vi.fn();
     const onDelete = vi.fn();
+    const onShare = vi.fn();
 
     render(
       <ResumeCard
@@ -28,6 +29,7 @@ describe('ResumeCard', () => {
         onEdit={onEdit}
         onDuplicate={onDuplicate}
         onDelete={onDelete}
+        onShare={onShare}
       />
     );
 
@@ -49,6 +51,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 
@@ -66,6 +69,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 
@@ -85,6 +89,7 @@ describe('ResumeCard', () => {
         onEdit={onEdit}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 
@@ -104,6 +109,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={onDuplicate}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 
@@ -123,6 +129,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={onDelete}
+        onShare={vi.fn()}
       />
     );
 
@@ -130,6 +137,26 @@ describe('ResumeCard', () => {
     fireEvent.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onShare when share button is clicked', () => {
+    const onShare = vi.fn();
+    render(
+      <ResumeCard
+        resume={mockResume}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onShare={onShare}
+      />
+    );
+
+    const shareButton = screen.getByTitle('Share Resume');
+    fireEvent.click(shareButton);
+
+    expect(onShare).toHaveBeenCalledTimes(1);
   });
 
   it('shows private badge when is_public is false', () => {
@@ -146,6 +173,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 
@@ -166,6 +194,7 @@ describe('ResumeCard', () => {
         onEdit={vi.fn()}
         onDuplicate={vi.fn()}
         onDelete={vi.fn()}
+        onShare={vi.fn()}
       />
     );
 

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -8,6 +8,7 @@ interface ResumeCardProps {
   onEdit: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
+  onShare: () => void;
 }
 
 /**
@@ -23,6 +24,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
   onEdit,
   onDuplicate,
   onDelete,
+  onShare,
 }) => {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -69,6 +71,14 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
 
           {/* Action buttons */}
           <div className="flex items-center gap-1">
+            <button
+              onClick={onShare}
+              className="p-2 text-slate-400 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
+              title="Share Resume"
+              aria-label="Share Resume"
+            >
+              <span className="material-symbols-outlined text-[20px]">share</span>
+            </button>
             <button
               onClick={onEdit}
               className="p-2 text-slate-400 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"

--- a/components/ShareDialog.tsx
+++ b/components/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { ShareLink } from '../types';
 import { shareResume } from '../utils/api-client';
 import { showSuccessToast, showErrorToast } from '../utils/toast';
@@ -23,6 +23,63 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ resumeId, onClose }) => {
   const [maxViews, setMaxViews] = useState<number | null>(null);
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus trap and Escape key handling
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusables.length === 0) return;
+
+        const first = focusables[0] as HTMLElement;
+        const last = focusables[focusables.length - 1] as HTMLElement;
+
+        if (e.shiftKey && document.activeElement === first) {
+          last.focus();
+          e.preventDefault();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          first.focus();
+          e.preventDefault();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Initial focus on the first interactive element or the container
+    // We prefer focusing the container to avoid surprising context shifts,
+    // but focusing the first input is standard for modals.
+    // Here, let's focus the close button or the first permission button.
+    const firstInput = dialogRef.current?.querySelector('button, input, select') as HTMLElement;
+    if (firstInput) {
+        firstInput.focus();
+    } else {
+        dialogRef.current?.focus();
+    }
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Auto-focus copy button when share link is created
+  useEffect(() => {
+    if (shareLink && dialogRef.current) {
+      // Small timeout to allow render
+      setTimeout(() => {
+        // Find the copy button by its distinctive class or aria-label
+        const copyBtn = dialogRef.current?.querySelector('button[aria-label="Copy share link"]') as HTMLElement;
+        copyBtn?.focus();
+      }, 50);
+    }
+  }, [shareLink]);
 
   const handleCreateShare = async () => {
     try {
@@ -75,8 +132,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ resumeId, onClose }) => {
       aria-modal="true"
     >
       <div
-        className="bg-white rounded-2xl shadow-2xl max-w-md w-full"
+        ref={dialogRef}
+        className="bg-white rounded-2xl shadow-2xl max-w-md w-full outline-none"
         onClick={(e) => e.stopPropagation()}
+        tabIndex={-1}
       >
         <div className="p-6 border-b border-slate-200 flex justify-between items-center">
           <h2 id="share-dialog-title" className="text-xl font-bold text-slate-900">
@@ -167,6 +226,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ resumeId, onClose }) => {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                   >
                     <span className="material-symbols-outlined text-[20px]">
                       {showPassword ? 'visibility_off' : 'visibility'}
@@ -199,7 +259,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ resumeId, onClose }) => {
             </div>
           ) : (
             <div className="space-y-4">
-              <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+              <div
+                className="p-4 bg-green-50 border border-green-200 rounded-lg"
+                role="alert"
+              >
                 <div className="flex items-center gap-2 text-green-800">
                   <span className="material-symbols-outlined text-[24px]">
                     check_circle
@@ -221,6 +284,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ resumeId, onClose }) => {
                   />
                   <button
                     onClick={handleCopyLink}
+                    aria-label="Copy share link"
                     className="px-4 py-2.5 bg-primary-600 text-white font-bold rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
                   >
                     <span className="material-symbols-outlined text-[20px]">

--- a/pages/ResumeManagement.tsx
+++ b/pages/ResumeManagement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Sidebar from '../components/Sidebar';
 import ResumeCard from '../components/ResumeCard';
+import ShareDialog from '../components/ShareDialog';
 import { Route, ResumeMetadata, BulkOperationType, BulkOperationResult } from '../types';
 import { listResumes, bulkOperation } from '../utils/api-client';
 import { showErrorToast, showSuccessToast } from '../utils/toast';
@@ -22,6 +23,7 @@ const ResumeManagement: React.FC = () => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showTagDialog, setShowTagDialog] = useState(false);
   const [showResultDialog, setShowResultDialog] = useState(false);
+  const [sharingResumeId, setSharingResumeId] = useState<number | null>(null);
   const [tagInput, setTagInput] = useState('');
   const [operationResult, setOperationResult] = useState<BulkOperationResult | null>(null);
   const [pendingOperation, setPendingOperation] = useState<BulkOperationType | null>(null);
@@ -227,6 +229,10 @@ const ResumeManagement: React.FC = () => {
     }
   };
 
+  const handleShare = (id: number) => {
+    setSharingResumeId(id);
+  };
+
   // Get selected resumes for display
   const selectedResumes = resumes.filter((r) => selectedIds.has(r.id));
 
@@ -371,12 +377,21 @@ const ResumeManagement: React.FC = () => {
                   onEdit={() => handleEdit(resume.id)}
                   onDuplicate={() => handleDuplicate(resume.id)}
                   onDelete={() => handleDelete(resume.id)}
+                  onShare={() => handleShare(resume.id)}
                 />
               ))}
             </div>
           )}
         </main>
       </div>
+
+      {/* Share Dialog */}
+      {sharingResumeId !== null && (
+        <ShareDialog
+          resumeId={sharingResumeId}
+          onClose={() => setSharingResumeId(null)}
+        />
+      )}
 
       {/* Delete Confirmation Dialog */}
       {showDeleteDialog && (


### PR DESCRIPTION
This PR enhances the UX and accessibility of the Share Resume feature.

**Key Changes:**
1.  **Accessibility**:
    -   Implemented a focus trap in `ShareDialog` to prevent keyboard navigation from escaping the modal.
    -   Added Escape key support to close the dialog.
    -   Added `role="alert"` to the success message for screen readers.
    -   Added `aria-label` to the icon-only "Share" button in `ResumeCard`.

2.  **Delight**:
    -   Implemented "Smart Focus": When a share link is generated, focus automatically moves to the "Copy" button, allowing users to copy the link with a single keystroke (Enter).

3.  **Integration**:
    -   Wired up the previously unused `ShareDialog` component in `ResumeManagement.tsx`.
    -   Added a "Share" button to `ResumeCard`.

**Verification:**
-   Manual verification of focus logic via code review.
-   Ran `pnpm test` successfully (259 tests passed), ensuring no regressions and validating the new `onShare` interaction.

---
*PR created automatically by Jules for task [7500254349494145918](https://jules.google.com/task/7500254349494145918) started by @anchapin*