### PR TITLE
feat: Replace mock data with real API for Job Applications (#318)

### DIFF
--- a/pages/JobApplications.tsx
+++ b/pages/JobApplications.tsx
@@ -1,41 +1,86 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { JobApplication, SimpleResumeData, ATSReport } from '../types';
 import StatusBadge from '../components/StatusBadge';
-import { convertToAPIData, tailorResume, checkATSScore, TailoredResumeResponse } from '../utils/api-client';
+import { convertToAPIData, tailorResume, checkATSScore, TailoredResumeResponse, 
+  listJobApplications, createJobApplication, updateJobApplication, deleteJobApplication,
+  getApplicationStats, ApplicationStats, ApplicationStatus } from '../utils/api-client';
+
+/** Map API status to display status */
+const mapApiStatusToDisplay = (status: ApplicationStatus): string => {
+  const statusMap: Record<ApplicationStatus, string> = {
+    'draft': 'Draft',
+    'applied': 'Applied',
+    'screening': 'Screening',
+    'interviewing': 'Interview',
+    'offer': 'Offer',
+    'accepted': 'Accepted',
+    'rejected': 'Rejected',
+    'withdrawn': 'Withdrawn'
+  };
+  return statusMap[status] || status;
+};
+
+/** Map display status to API status */
+const mapDisplayToApiStatus = (status: string): ApplicationStatus => {
+  const statusMap: Record<string, ApplicationStatus> = {
+    'Draft': 'draft',
+    'Applied': 'applied',
+    'Screening': 'screening',
+    'Interview': 'interviewing',
+    'Offer': 'offer',
+    'Accepted': 'accepted',
+    'Rejected': 'rejected',
+    'Withdrawn': 'withdrawn'
+  };
+  return statusMap[status] || 'draft';
+};
 
 /** Extended JobApplication type with tracking fields */
-interface TrackedJobApplication extends JobApplication {
+interface TrackedJobApplication {
+  id: number;
+  company_name: string;
+  job_title: string;
+  job_url?: string;
+  location?: string;
+  status: ApplicationStatus;
   resumeVariant?: string;
   applicationMethod?: 'LinkedIn' | 'Direct' | 'Referral' | 'Indeed' | 'Other';
-  jobUrl?: string;
   notes?: string;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+  dateApplied?: string;
+  logo?: string;
 }
 
 /** Stats calculation from applications */
-const calculateStats = (apps: TrackedJobApplication[]) => {
+const calculateStats = (apps: TrackedJobApplication[], apiStats?: ApplicationStats) => {
+  // Use API stats if available
+  if (apiStats) {
+    return {
+      total: apiStats.total_applications,
+      sent: apiStats.total_applications,
+      pending: apiStats.by_status['applied'] || 0,
+      interviews: apiStats.by_status['interviewing'] || 0,
+      offers: apiStats.by_status['offer'] || 0,
+      rejected: apiStats.by_status['rejected'] || 0,
+      interviewRate: Math.round(apiStats.interview_rate * 100)
+    };
+  }
+  
+  // Fall back to calculating from apps array
   const total = apps.length;
   const sent = total;
-  const pending = apps.filter(a => a.status === 'Applied').length;
-  const interviews = apps.filter(a => a.status === 'Interview').length;
-  const offers = apps.filter(a => a.status === 'Offer').length;
-  const rejected = apps.filter(a => a.status === 'Rejected').length;
+  const pending = apps.filter(a => a.status === 'applied').length;
+  const interviews = apps.filter(a => a.status === 'interviewing').length;
+  const offers = apps.filter(a => a.status === 'offer').length;
+  const rejected = apps.filter(a => a.status === 'rejected').length;
   
   const responded = interviews + offers + rejected;
   const interviewRate = responded > 0 ? Math.round((interviews / responded) * 100) : 0;
   
   return { total, sent, pending, interviews, offers, rejected, interviewRate };
 };
-
-/** Mock data for job applications */
-const initialApplications: TrackedJobApplication[] = [
-  { id: '1', company: 'Google', role: 'Software Engineer', status: 'Applied', dateApplied: 'Oct 24, 2023', logo: 'https://lh3.googleusercontent.com/COxitqgJr1sJnIDe8-Ca402YwzGNcjqg84afM42nzQ7kXDD0jf986hws20DaEvp_ejg', resumeVariant: 'v1.0.0-backend', applicationMethod: 'LinkedIn', jobUrl: 'https://linkedin.com/jobs/123' },
-  { id: '2', company: 'Stripe', role: 'Product Designer', status: 'Interview', dateApplied: 'Oct 22, 2023', logo: 'https://b.stripecdn.com/docs-statics-srv/assets/b411c60/company-logos/dark/stripe.svg', resumeVariant: 'v1.0.0-design', applicationMethod: 'Referral', jobUrl: 'https://stripe.com/careers/456' },
-  { id: '3', company: 'Vercel', role: 'Frontend Developer', status: 'Offer', dateApplied: 'Oct 15, 2023', logo: 'https://assets.vercel.com/image/upload/front/favicon/vercel/180x180.png', resumeVariant: 'v1.0.0-frontend', applicationMethod: 'Direct', jobUrl: 'https://vercel.com/careers/789' },
-  { id: '4', company: 'Netflix', role: 'Senior UI Engineer', status: 'Rejected', dateApplied: 'Sep 28, 2023', logo: 'https://assets.nflxext.com/us/ffe/siteui/common/icons/nficon2016.png', resumeVariant: 'v1.0.0-backend', applicationMethod: 'LinkedIn' },
-  { id: '5', company: 'Airbnb', role: 'Full Stack Developer', status: 'Applied', dateApplied: 'Nov 01, 2023', logo: 'https://a0.muscache.com/airbnb/static/icons/android/airbnb-logo-256x256.png', resumeVariant: 'v1.0.0-fullstack', applicationMethod: 'Indeed' },
-  { id: '6', company: 'Microsoft', role: 'Software Engineer II', status: 'Interview', dateApplied: 'Oct 05, 2023', logo: 'https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b?ver=5c31', resumeVariant: 'v1.0.0-backend', applicationMethod: 'Referral' },
-  { id: '7', company: 'Amazon', role: 'Frontend Engineer', status: 'Applied', dateApplied: 'Nov 03, 2023', logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Amazon_logo.svg/1024px-Amazon_logo.svg.png', resumeVariant: 'v1.0.0-frontend', applicationMethod: 'LinkedIn' },
-];
 
 /**
  * @component
@@ -44,7 +89,9 @@ const initialApplications: TrackedJobApplication[] = [
  */
 const JobApplications: React.FC = () => {
   // Applications state
-  const [applications, setApplications] = useState<TrackedJobApplication[]>(initialApplications);
+  const [applications, setApplications] = useState<TrackedJobApplication[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
   
   // Resume tailoring state
   const [showTailorModal, setShowTailorModal] = useState<boolean>(false);
@@ -61,6 +108,36 @@ const JobApplications: React.FC = () => {
   const [isCheckingATS, setIsCheckingATS] = useState<boolean>(false);
   const [atsError, setAtsError] = useState<string | null>(null);
   const [atsReport, setAtsReport] = useState<ATSReport | null>(null);
+  
+  // Fetch applications from API on mount
+  useEffect(() => {
+    const fetchApplications = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const apps = await listJobApplications();
+        // Map API response to display format
+        const mappedApps: TrackedJobApplication[] = apps.map(app => ({
+          ...app,
+          dateApplied: new Date(app.created_at).toLocaleDateString('en-US', { 
+            month: 'short', 
+            day: 'numeric', 
+            year: 'numeric' 
+          }),
+          company: app.company_name,
+          role: app.job_title,
+        }));
+        setApplications(mappedApps);
+      } catch (err) {
+        console.error('Failed to load applications:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load applications');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    
+    fetchApplications();
+  }, []);
   
   // Calculate stats from applications
   const stats = useMemo(() => calculateStats(applications), [applications]);
@@ -283,31 +360,67 @@ const JobApplications: React.FC = () => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
-                {applications.map((app) => (
-                  <tr key={app.id} className="hover:bg-slate-50 transition-colors cursor-pointer group">
-                    <td className="px-6 py-5">
-                      <div className="flex items-center gap-4">
-                        <div className="bg-white rounded-lg size-10 flex items-center justify-center p-1 border border-slate-100 shadow-sm">
-                           <img src={app.logo} alt={app.company} className="max-w-full max-h-full object-contain" onError={(e) => { (e.target as HTMLImageElement).src = `https://ui-avatars.com/api/?name=${app.company}&background=random` }}/>
-                        </div>
-                        <span className="text-slate-900 font-bold text-sm group-hover:text-primary-600 transition-colors">{app.company}</span>
+                {isLoading ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-12 text-center">
+                      <div className="flex flex-col items-center justify-center">
+                        <span className="material-symbols-outlined animate-spin text-primary-600 text-4xl mb-4">progress_activity</span>
+                        <p className="text-slate-500 font-medium">Loading applications...</p>
                       </div>
                     </td>
-                    <td className="px-6 py-5 text-slate-700 text-sm font-medium">{app.role}</td>
-                    <td className="px-6 py-5 text-center"><StatusBadge status={app.status} /></td>
-                    <td className="px-6 py-5 text-slate-500 text-sm text-right font-medium">{app.dateApplied}</td>
-                    <td className="px-6 py-5 text-right">
-                        <button
-                            type="button"
-                            className="text-slate-400 hover:text-primary-600 transition-colors"
-                            aria-label="More options"
-                            title="More options"
+                  </tr>
+                ) : error ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-12 text-center">
+                      <div className="flex flex-col items-center justify-center text-red-500">
+                        <span className="material-symbols-outlined text-4xl mb-4">error</span>
+                        <p className="font-medium">{error}</p>
+                        <button 
+                          onClick={() => window.location.reload()}
+                          className="mt-4 px-4 py-2 bg-primary-600 text-white rounded-lg font-medium hover:bg-primary-700"
                         >
-                            <span className="material-symbols-outlined" aria-hidden="true">more_vert</span>
+                          Retry
                         </button>
+                      </div>
                     </td>
                   </tr>
-                ))}
+                ) : applications.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="px-6 py-12 text-center">
+                      <div className="flex flex-col items-center justify-center text-slate-400">
+                        <span className="material-symbols-outlined text-6xl mb-4">work_off</span>
+                        <p className="font-medium text-slate-500">No job applications yet</p>
+                        <p className="text-sm">Click "Add Application" to track your first job application</p>
+                      </div>
+                    </td>
+                  </tr>
+                ) : (
+                  applications.map((app) => (
+                    <tr key={app.id} className="hover:bg-slate-50 transition-colors cursor-pointer group">
+                      <td className="px-6 py-5">
+                        <div className="flex items-center gap-4">
+                          <div className="bg-white rounded-lg size-10 flex items-center justify-center p-1 border border-slate-100 shadow-sm">
+                            <img src={app.logo} alt={app.company_name} className="max-w-full max-h-full object-contain" onError={(e) => { (e.target as HTMLImageElement).src = `https://ui-avatars.com/api/?name=${encodeURIComponent(app.company_name)}&background=random` }}/>
+                          </div>
+                          <span className="text-slate-900 font-bold text-sm group-hover:text-primary-600 transition-colors">{app.company_name}</span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-5 text-slate-700 text-sm font-medium">{app.job_title}</td>
+                      <td className="px-6 py-5 text-center"><StatusBadge status={mapApiStatusToDisplay(app.status)} /></td>
+                      <td className="px-6 py-5 text-slate-500 text-sm text-right font-medium">{app.dateApplied}</td>
+                      <td className="px-6 py-5 text-right">
+                          <button
+                              type="button"
+                              className="text-slate-400 hover:text-primary-600 transition-colors"
+                              aria-label="More options"
+                              title="More options"
+                          >
+                              <span className="material-symbols-outlined" aria-hidden="true">more_vert</span>
+                          </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
         </div>

--- a/utils/api-client.ts
+++ b/utils/api-client.ts
@@ -409,3 +409,150 @@ export async function getDefaultPriorities(): Promise<ComparisonPriority> {
 export async function updatePriorities(priorities: ComparisonPriority): Promise<ComparisonPriority> {
   return priorities;
 }
+
+// Job Application Types
+export type ApplicationStatus = 'draft' | 'applied' | 'screening' | 'interviewing' | 'offer' | 'accepted' | 'rejected' | 'withdrawn';
+
+export interface JobApplication {
+  id: number;
+  company_name: string;
+  job_title: string;
+  job_url?: string;
+  location?: string;
+  status: ApplicationStatus;
+  salary_min?: number;
+  salary_max?: number;
+  salary_currency: string;
+  resume_id?: number;
+  notes?: string;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JobApplicationCreate {
+  company_name: string;
+  job_title: string;
+  job_url?: string;
+  location?: string;
+  salary_min?: number;
+  salary_max?: number;
+  salary_currency?: string;
+  resume_id?: number;
+  notes?: string;
+  tags?: string[];
+}
+
+export interface JobApplicationUpdate {
+  status?: ApplicationStatus;
+  company_name?: string;
+  job_title?: string;
+  notes?: string;
+  tags?: string[];
+}
+
+export interface ApplicationStats {
+  total_applications: number;
+  by_status: Record<string, number>;
+  response_rate: number;
+  interview_rate: number;
+  offer_rate: number;
+}
+
+export interface ApplicationFunnel {
+  stages: Array<{
+    name: string;
+    count: number;
+    percentage: number;
+  }>;
+  total_applications: number;
+}
+
+export interface ApplicationTimeline {
+  timeline: Array<{
+    date: string;
+    count: number;
+    status: string;
+  }>;
+}
+
+export interface UpcomingEvent {
+  id: number;
+  title: string;
+  date: string;
+  type: 'interview' | 'follow_up' | 'deadline';
+  application_id: number;
+  company_name: string;
+}
+
+// Job Application API Functions
+
+export async function createJobApplication(app: JobApplicationCreate): Promise<JobApplication> {
+  const response = await fetch(`${API_URL}/v1/applications`, {
+    method: 'POST',
+    headers: { ...getHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(app),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Failed to create application' }));
+    throw new Error(error.detail || 'Failed to create application');
+  }
+  return response.json();
+}
+
+export async function listJobApplications(status?: ApplicationStatus, limit = 50, offset = 0): Promise<JobApplication[]> {
+  const params = new URLSearchParams();
+  if (status) params.append('status', status);
+  params.append('limit', limit.toString());
+  params.append('offset', offset.toString());
+  
+  const response = await fetch(`${API_URL}/v1/applications?${params}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to list applications');
+  return response.json();
+}
+
+export async function getJobApplication(id: number): Promise<JobApplication> {
+  const response = await fetch(`${API_URL}/v1/applications/${id}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to get application');
+  return response.json();
+}
+
+export async function updateJobApplication(id: number, updates: JobApplicationUpdate): Promise<JobApplication> {
+  const response = await fetch(`${API_URL}/v1/applications/${id}`, {
+    method: 'PUT',
+    headers: { ...getHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  });
+  if (!response.ok) throw new Error('Failed to update application');
+  return response.json();
+}
+
+export async function deleteJobApplication(id: number): Promise<void> {
+  const response = await fetch(`${API_URL}/v1/applications/${id}`, { method: 'DELETE', headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to delete application');
+}
+
+export async function getApplicationStats(days = 30): Promise<ApplicationStats> {
+  const response = await fetch(`${API_URL}/v1/applications/analytics/stats?days=${days}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to get application stats');
+  return response.json();
+}
+
+export async function getApplicationFunnel(days = 30): Promise<ApplicationFunnel> {
+  const response = await fetch(`${API_URL}/v1/applications/analytics/funnel?days=${days}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to get application funnel');
+  return response.json();
+}
+
+export async function getApplicationTimeline(days = 30): Promise<ApplicationTimeline> {
+  const response = await fetch(`${API_URL}/v1/applications/analytics/timeline?days=${days}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to get application timeline');
+  return response.json();
+}
+
+export async function getUpcomingEvents(days = 7): Promise<UpcomingEvent[]> {
+  const response = await fetch(`${API_URL}/v1/applications/analytics/upcoming?days=${days}`, { headers: getHeaders() });
+  if (!response.ok) throw new Error('Failed to get upcoming events');
+  const data = await response.json();
+  return data.events || [];
+}


### PR DESCRIPTION
## Summary

Replaces the mock data in JobApplications.tsx with real API integration to fetch job applications from the backend.

## Changes

- Added API client functions in utils/api-client.ts:
  - `createJobApplication()` - Create new job application
  - `listJobApplications()` - List all applications
  - `getJobApplication()` - Get single application
  - `updateJobApplication()` - Update application
  - `deleteJobApplication()` - Delete application
  - `getApplicationStats()` - Get application statistics
  - `getApplicationFunnel()` - Get funnel analytics
  - `getApplicationTimeline()` - Get timeline data
  - `getUpcomingEvents()` - Get upcoming events

- Added TypeScript types:
  - `ApplicationStatus` - Application status enum
  - `JobApplication` - Application interface
  - `JobApplicationCreate` / `JobApplicationUpdate`
  - `ApplicationStats`, `ApplicationFunnel`, `ApplicationTimeline`
  - `UpcomingEvent`

- Updated JobApplications.tsx:
  - Replaced mock data with API calls using useEffect
  - Added loading, error, and empty states
  - Added status mapping between API and display format
  - Integrated with existing Tailor Resume and ATS Check modals

## Testing

- Page loads with loading state while fetching data
- Shows error state if API fails
- Shows empty state when no applications exist
- Displays applications in table with correct status badges

Closes #318