### PR TITLE
fix(test): Fix Vitest Configuration (#381)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-toastify": "^4.0.2",
     "@vitejs/plugin-react": "^5.0.0",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-istanbul": "^4.0.18",
     "jsdom": "^28.0.0",
     "typedoc": "^0.28.17",
     "typescript": "~5.8.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => {
           },
         },
         coverage: {
-          provider: 'v8',
+          provider: 'istanbul',
           reporter: ['text', 'json', 'html'],
           exclude: [
             'node_modules/',


### PR DESCRIPTION
## Issue #381
Vitest configuration broken with node:inspector/promises module error.

## Changes
- Switched coverage provider from v8 to istanbul
- Updated dependencies in package.json
- v8 requires Node.js 20+, istanbul works with Node.js 18.19.1+

## Verification
npm test -- --coverage runs without module errors

Closes #381