### PR TITLE
#406 Set Up ESLint + Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,38 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "react-hooks",
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.venv
+coverage
+build
+*.lock
+*.yaml
+*.yml
+.git

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,44 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  {
+    ignores: ['node_modules/**', 'dist/**', '.venv/**', 'coverage/**', 'build/**', '*.d.ts'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        browser: true,
+        es2021: true,
+        node: true,
+      },
+    },
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "test:coverage": "vitest --coverage",
     "test:a11y": "vitest tests/a11y --run",
     "a11y:scan": "node scripts/a11y-scan.js",
-    "docs": "typedoc --out docs --entryPoints components/ pages/ utils/ hooks/ --excludeNotDocumented --excludeInternal --theme default"
+    "docs": "typedoc --out docs --entryPoints components/ pages/ utils/ hooks/ --excludeNotDocumented --excludeInternal --theme default",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "react": "^19.2.4",
@@ -23,6 +27,7 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.10.2",
+    "@eslint/js": "^10.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -31,14 +36,22 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/react-toastify": "^4.0.2",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-istanbul": "^4.0.18",
     "axe-core": "^4.10.2",
+    "eslint": "^9.39.3",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "happy-dom": "^20.7.0",
     "jest-axe": "^8.0.0",
     "jsdom": "^28.0.0",
+    "prettier": "^3.8.1",
     "typedoc": "^0.28.17",
     "typescript": "~5.8.2",
+    "typescript-eslint": "^8.56.1",
     "vite": "^6.2.0",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
## Issue #406: Set Up ESLint + Prettier

### Changes
- Install ESLint, Prettier, and TypeScript plugins
- Create .eslintrc.json with React/TypeScript support  
- Create eslint.config.js for ESLint 9 compatibility
- Create .prettierrc with formatting rules
- Add npm scripts: lint, lint:fix, format, format:check
- Create ignore files for ESLint and Prettier

### Testing
```bash
npm run lint     # Check linting
npm run lint:fix # Auto-fix issues
npm run format   # Auto-format code
```

Closes #406