### PR TITLE
fix: Remove debug logging and fix hardcoded mock resume ID (#480)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -159,7 +159,9 @@ function App() {
     if (token && TokenManager.isTokenExpired(token)) {
       // Token is expired, remove it
       TokenManager.removeToken();
-      console.warn('Authentication token expired, please log in again');
+      if (import.meta.env.DEV) {
+        console.warn('Authentication token expired, please log in again');
+      }
       // In a real app, you might show a notification or redirect to login
     }
 
@@ -175,24 +177,28 @@ function App() {
           projects: Array.isArray(savedData.projects) ? savedData.projects : [],
         };
         setResumeData(validatedData);
-        console.log('Resume data loaded and validated:', {
-          skills: validatedData.skills.length,
-          education: validatedData.education.length,
-          experience: validatedData.experience.length,
-        });
-      } else {
+        if (import.meta.env.DEV) {
+          console.log('Resume data loaded and validated:', {
+            skills: validatedData.skills.length,
+            education: validatedData.education.length,
+            experience: validatedData.experience.length,
+          });
+        }
+      } else if (import.meta.env.DEV) {
         console.log('No saved resume data found, using initial data');
       }
     } catch (error) {
       if (error instanceof StorageError) {
-        console.error('Storage error:', error.message, error.type);
+        if (import.meta.env.DEV) {
+          console.error('Storage error:', error.message, error.type);
+        }
         // Show a user-friendly error message
         const errorMessage = getErrorMessage(error);
         setStorageError(errorMessage);
 
         // Auto-dismiss error after 5 seconds
         setTimeout(() => setStorageError(null), 5000);
-      } else {
+      } else if (import.meta.env.DEV) {
         console.error('Unexpected error loading resume data:', error);
       }
     } finally {
@@ -213,20 +219,24 @@ function App() {
       try {
         saveResumeData(resumeData);
         setSaveStatus('saved');
-        console.log('Resume data saved to localStorage');
+        if (import.meta.env.DEV) {
+          console.log('Resume data saved to localStorage');
+        }
 
         // Reset to idle after 3 seconds
         setTimeout(() => setSaveStatus('idle'), 3000);
       } catch (error) {
         setSaveStatus('error');
         if (error instanceof StorageError) {
-          console.error('Storage error:', error.message, error.type);
+          if (import.meta.env.DEV) {
+            console.error('Storage error:', error.message, error.type);
+          }
           const errorMessage = getErrorMessage(error);
           setStorageError(errorMessage);
 
           // Auto-dismiss error after 5 seconds
           setTimeout(() => setStorageError(null), 5000);
-        } else {
+        } else if (import.meta.env.DEV) {
           console.error('Unexpected error saving resume data:', error);
         }
 

--- a/pages/Workspace.tsx
+++ b/pages/Workspace.tsx
@@ -8,15 +8,18 @@ import { getResume, listResumeVersions, listComments } from '../utils/api-client
 
 /**
  * @interface WorkspaceProps
- * @description Props for the Workspace component
- * @property {SimpleResumeData} resumeData - The resume data to use in the workspace
+ * @description Props for Workspace component
+ * @property {SimpleResumeData} resumeData - The resume data to use in workspace
  * @property {Function} onNavigate - Callback function to handle navigation
+ * @property {number} resumeId - Optional resume ID for fetching metadata (versions, comments)
  */
 interface WorkspaceProps {
-  /** The resume data to use in the workspace */
+  /** The resume data to use in workspace */
   resumeData: SimpleResumeData;
   /** Callback function to handle navigation */
   onNavigate: (route: Route) => void;
+  /** Optional resume ID for fetching metadata (versions, comments) */
+  resumeId?: number;
 }
 
 /** Available tab types for the workspace */
@@ -29,8 +32,9 @@ const TABS: TabType[] = ['Resume', 'Cover Letter', 'Keywords', 'Suggestions', 'A
  * @component
  * @description Workspace page component for tailoring resumes to job descriptions
  * @param {WorkspaceProps} props - Component properties
- * @param {SimpleResumeData} props.resumeData - The resume data to use in the workspace
+ * @param {SimpleResumeData} props.resumeData - The resume data to use in workspace
  * @param {Function} props.onNavigate - Callback function to handle navigation
+ * @param {number} props.resumeId - Optional resume ID for fetching metadata
  * @returns {JSX.Element} The rendered workspace page component
  *
  * @example
@@ -38,10 +42,15 @@ const TABS: TabType[] = ['Resume', 'Cover Letter', 'Keywords', 'Suggestions', 'A
  * <Workspace
  *   resumeData={sampleResumeData}
  *   onNavigate={(route) => console.log(`Navigating to ${route}`)}
+ *   resumeId={1}
  * />
  * ```
  */
-const Workspace: React.FC<WorkspaceProps> = ({ resumeData, onNavigate }) => {
+const Workspace: React.FC<WorkspaceProps> = ({
+  resumeData,
+  onNavigate,
+  resumeId: propResumeId,
+}) => {
   const {
     generatePackage,
     generateCoverLetterRequest,
@@ -73,8 +82,8 @@ const Workspace: React.FC<WorkspaceProps> = ({ resumeData, onNavigate }) => {
   const [lastUpdated, setLastUpdated] = useState<string>('');
   const [loadingMetadata, setLoadingMetadata] = useState<boolean>(true);
 
-  // Mock resume ID - in real app, this would come from props
-  const mockResumeId = 1;
+  // Use provided resumeId from props, default to 1 if not provided
+  const resumeId = propResumeId ?? 1;
 
   // Initialize with API variants once loaded
   useEffect(() => {
@@ -93,8 +102,8 @@ const Workspace: React.FC<WorkspaceProps> = ({ resumeData, onNavigate }) => {
       try {
         setLoadingMetadata(true);
         const [versions, comments] = await Promise.all([
-          listResumeVersions(mockResumeId),
-          listComments(mockResumeId),
+          listResumeVersions(resumeId),
+          listComments(resumeId),
         ]);
         setVersionCount(versions.length);
         setCommentCount(comments.length);
@@ -117,7 +126,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ resumeData, onNavigate }) => {
     };
 
     loadMetadata();
-  }, [mockResumeId]);
+  }, [resumeId]);
 
   // Helper function to format time ago
   const formatTimeAgo = (date: Date): string => {


### PR DESCRIPTION
## Summary

- Gate all console.log, console.warn, and console.error behind import.meta.env.DEV
- Replace hardcoded mockResumeId with prop in Workspace component
- Add optional resumeId prop to WorkspaceProps interface
- Use provided resumeId from props, default to 1 if not provided
- Update all references to use the new resumeId variable

Changes made:
- App.tsx: All debug logs now only appear in development mode
- Workspace.tsx: Removed mockResumeId, replaced with prop-based resumeId

Fixes #480

## Changes

- **App.tsx**: Wrapped all console statements with import.meta.env.DEV checks to prevent debug logs in production
- **pages/Workspace.tsx**: Added optional resumeId prop to WorkspaceProps interface and replaced hardcoded mockResumeId

## Benefits

- Production builds no longer output debug logging to console
- Reduced console noise for end users
- Workspace component is now more flexible and can receive resume ID from parent
- Makes it easier to implement multi-resume workflows in the future