### PR TITLE
fix: resolve URL format issue in integration tests

### DIFF
--- a/tests/integration/test-utils.ts
+++ b/tests/integration/test-utils.ts
@@ -68,6 +68,7 @@ export async function cleanupTestAPI(context: TestContext): Promise<void> {
 function createMockAPIClient(): MockAPIClient {
   const storage: Map<string, any> = new Map();
   const pdfCache: Map<string, any> = new Map();
+  const renderPdfCache: Map<string, string> = new Map();
   let restorationCount = 0;
 
   return {
@@ -282,12 +283,34 @@ function createMockAPIClient(): MockAPIClient {
       }
 
       try {
-        // Simulate PDF generation
+        // Create cache key from resume data and variant
+        const cacheKey = JSON.stringify({ resume: resumeData, variant });
+
+        // Check cache first
+        if (renderPdfCache.has(cacheKey)) {
+          const cachedUrl = renderPdfCache.get(cacheKey)!;
+          const pdfBuffer = Buffer.from('PDF_MOCK_DATA');
+          return {
+            status: 200,
+            data: {
+              pdf_url: cachedUrl,
+              size: pdfBuffer.length,
+              generated_at: new Date().toISOString(),
+              variant: variant || 'standard',
+            },
+            cached: true,
+          };
+        }
+
+        // Generate new PDF URL and cache it
+        const pdfUrl = 'https://storage.example.com/resume-' + Date.now() + '.pdf';
+        renderPdfCache.set(cacheKey, pdfUrl);
+
         const pdfBuffer = Buffer.from('PDF_MOCK_DATA');
         return {
           status: 200,
           data: {
-            pdf_url: 'https://storage.example.com/resume-' + Date.now() + '.pdf',
+            pdf_url: pdfUrl,
             size: pdfBuffer.length,
             generated_at: new Date().toISOString(),
             variant: variant || 'standard',


### PR DESCRIPTION
Closes #496

## Summary
- Added PDF rendering cache to mock API to ensure consistent URL generation
- The renderPDF function now caches results based on resume data and variant
- Fixed two failing tests: "should cache PDF generation results" (in both PDF Rendering and Performance sections)

## Changes
- Added `renderPdfCache` Map to store cached PDF URLs
- Updated `renderPDF` function to check cache before generating new URL
- Returns consistent URL for identical resume data across multiple calls

## Testing
- All 30 integration tests pass (29 passed, 1 skipped)
- Verified that consecutive PDF render calls now return the same URL