### PR TITLE
Fix #575: Fix JWT Secret Auto-Generation Issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,10 +131,12 @@ LOG_FORMAT=json
 # LOG_FILE=/var/log/resumeai/api.log
 
 ## Security Configuration
-# SECRET_KEY: Used for JWT signing and session management
+# JWT_SECRET: Secret key for JWT token signing
+# IMPORTANT: This must be set and remain constant across server restarts
+# If this changes, all existing authentication tokens will be invalidated
 # Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
-# REQUIRED for production
-# SECRET_KEY=your_secret_key_here
+# REQUIRED for production (fails fast if missing)
+# JWT_SECRET=your_jwt_secret_here
 #
 # CORS_ORIGINS: Allowed origins for cross-origin requests
 # - Development: ["http://localhost:5173", "http://localhost:3000"]
@@ -210,7 +212,7 @@ LOG_FORMAT=json
 # Production (required for deployment):
 # - All development variables
 # - MASTER_API_KEY (strong random value)
-# - SECRET_KEY (JWT signing)
+# - JWT_SECRET (constant across restarts, required for token persistence)
 # - DEBUG=false
 # - REQUIRE_API_KEY=true
 # - Proper CORS_ORIGINS configured

--- a/resume-api/.env.test
+++ b/resume-api/.env.test
@@ -23,3 +23,6 @@ ENABLE_RATE_LIMITING=true
 RATE_LIMIT_PDF=10/minute
 RATE_LIMIT_TAILOR=30/minute
 RATE_LIMIT_VARIANTS=60/minute
+
+# JWT Configuration (for testing)
+JWT_SECRET=test_jwt_secret_for_testing_only

--- a/resume-api/config/__init__.py
+++ b/resume-api/config/__init__.py
@@ -7,7 +7,7 @@ import secrets
 from pathlib import Path
 from typing import Optional, Union
 
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings
 from pydantic_settings import SettingsConfigDict
 
@@ -105,27 +105,42 @@ class Settings(BaseSettings):
 
     @field_validator("jwt_secret")
     @classmethod
-    def validate_jwt_secret(cls, v: str) -> str:
+    def validate_jwt_secret(cls, v: str, info: ValidationInfo) -> str:
         """
-        Validate JWT secret is secure.
+        Validate JWT secret is provided and secure.
 
-        This validator checks against multiple insecure defaults and ensures
-        the secret meets minimum length requirements. If an insecure default
-        is found, a secure random secret is generated.
+        Fails fast if JWT_SECRET is missing in production (debug=False).
         """
+        if not v or v == "":
+            debug = info.data.get("debug", False)
+            if not debug:
+                raise ValueError(
+                    "JWT_SECRET environment variable is required in production. "
+                    "Set it to a secure random value: "
+                    "python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+                )
+            logger = logging.getLogger("config")
+            logger.warning(
+                "SECURITY WARNING: JWT_SECRET not set. "
+                "Using temporary secret for development. "
+                "Set JWT_SECRET environment variable."
+            )
+            return secrets.token_urlsafe(32)
+
         insecure_defaults = [
             "your-secret-key-change-in-production",
             "your-super-secret-jwt-key-change-in-production",
+            "changeme",
+            "secret",
+            "test-secret",
         ]
 
         if v in insecure_defaults:
-            logger = logging.getLogger("config")
-            logger.critical(
-                "SECURITY WARNING: Using insecure default JWT_SECRET! "
-                "Generating a random temporary secret. "
-                "Set JWT_SECRET environment variable in production."
+            raise ValueError(
+                "SECURITY ERROR: JWT_SECRET is set to an insecure default value. "
+                "Set JWT_SECRET to a secure random value: "
+                "python -c 'import secrets; print(secrets.token_urlsafe(32))'"
             )
-            return secrets.token_urlsafe(32)
 
         if len(v) < 32:
             logger = logging.getLogger("config")


### PR DESCRIPTION
Fixes #575

## Summary
- Requires JWT_SECRET from environment variable
- Fails fast if SECRET missing in production
- Updates .env.example with JWT_SECRET
- Prevents token invalidation on server restart

## Changes
- Modified resume-api/config/__init__.py to require JWT_SECRET from env
- Added fail-fast error if JWT_SECRET missing in production
- Updated .env.example and .env.test with JWT_SECRET documentation

## Testing
- Tested token persistence across restarts
- Verified fail-fast error behavior
- Ran pytest, flake8, and mypy