### PR TITLE
Fix #524: Resolve Circular Database Dependency

### DIFF
--- a/resume-api/database.py
+++ b/resume-api/database.py
@@ -81,7 +81,6 @@ class Resume(Base):
     owner = relationship("User", back_populates="resumes")
     versions = relationship(
         "ResumeVersion",
-        foreign_keys="ResumeVersion.resume_id",
         back_populates="resume",
         cascade="all, delete-orphan",
     )


### PR DESCRIPTION
Fixes #524

## Summary
Removes redundant `foreign_keys` parameter from Resume.versions relationship to resolve potential circular dependency issues. Follows SQLAlchemy best practices for one-to-many relationships.

## Changes
- Remove `foreign_keys="ResumeVersion.resume_id"` from Resume.versions relationship
- ResumeVersion already has resume_id FK column and defines the relationship back to Resume
- Eliminates potential circular dependency confusion during migration generation
- Database migrations should work without requiring `use_alter=True`

## Technical Details
The Resume.versions relationship had a redundant foreign_keys parameter that pointed
to ResumeVersion.resume_id. Since ResumeVersion already has this foreign key column
defined and explicitly specifies the relationship back to Resume, the foreign_keys
parameter in Resume.versions was unnecessary and could cause confusion or circular
dependency warnings during migration generation.

**Before:**


**After:**


This is the standard SQLAlchemy pattern for one-to-many relationships.

## Testing
- Verified app loads successfully with new relationship configuration
- Code follows project formatting standards (black check passed)

## Related Issues
Closes #524