### PR TITLE
fix: Implement team CRUD endpoints (#726)

### DIFF
--- a/resume-api/api/team_routes.py
+++ b/resume-api/api/team_routes.py
@@ -257,7 +257,7 @@ async def get_team(
     Rate limit: 30 requests per minute per API key.
     """
     try:
-        auth.user_id if hasattr(auth, "user_id") else 1
+        user_id = auth.user_id if hasattr(auth, "user_id") else 1
 
         stmt = (
             select(Team)
@@ -664,7 +664,7 @@ async def list_team_members(
     Rate limit: 30 requests per minute per API key.
     """
     try:
-        auth.user_id if hasattr(auth, "user_id") else 1
+        user_id = auth.user_id if hasattr(auth, "user_id") else 1
 
         team_stmt = select(Team).where(Team.id == team_id)
         result = await db.execute(team_stmt)
@@ -709,6 +709,88 @@ async def list_team_members(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list team members: {str(e)}",
         )
+
+
+@router.get(
+    "/v1/teams/{team_id}/members/{member_id}",
+    response_model=TeamMemberResponse,
+    responses={
+        401: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        429: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+    },
+    tags=["Team Collaboration"],
+)
+@rate_limit("30/minute")
+async def get_team_member(
+    request: Request,
+    team_id: int,
+    member_id: int,
+    auth: AuthorizedAPIKey,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Get a specific team member by ID.
+
+    Requires API key authentication via X-API-KEY header.
+
+    Rate limit: 30 requests per minute per API key.
+    """
+    try:
+        user_id = auth.user_id if hasattr(auth, "user_id") else 1
+
+        team_stmt = select(Team).where(Team.id == team_id)
+        result = await db.execute(team_stmt)
+        team = result.scalar_one_or_none()
+
+        if not team:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Team {team_id} not found",
+            )
+
+        member_stmt = (
+            select(TeamMember)
+            .where(
+                and_(
+                    TeamMember.team_id == team_id,
+                    TeamMember.user_id == member_id,
+                )
+            )
+            .options(selectinload(TeamMember.user))
+        )
+        result = await db.execute(member_stmt)
+        member = result.scalar_one_or_none()
+
+        if not member:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Member {member_id} not found in team {team_id}",
+            )
+
+        return TeamMemberResponse(
+            user_id=member.user.id,
+            email=member.user.email,
+            username=member.user.username,
+            role=member.role,
+            joined_at=(
+                member.joined_at.isoformat()
+                if member.joined_at
+                else datetime.utcnow().isoformat()
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get team member: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get team member: {str(e)}",
+        )
+
+
 
 
 @router.put(


### PR DESCRIPTION
## Summary
Implements the missing team CRUD endpoints for issue #726:

- **GET /api/v1/teams/{team_id}/members/{member_id}** - Get a specific team member by ID
- **PUT /api/v1/teams/{team_id}/members/{user_id}** - Already implemented
- **DELETE /api/v1/teams/{team_id}/members/{user_id}** - Already implemented
- **POST /api/v1/teams/{team_id}/members** - Already implemented (invite_team_member)

## Changes
1. Add new GET endpoint for retrieving a single team member
2. Fix user_id assignment bug in get_team function (line 260)
3. Fix user_id assignment bug in list_team_members function (line 667)

## Testing
- Verified Python syntax is valid
- Code follows existing patterns in the file