### PR TITLE
fix: React hooks dependencies (#728)

### DIFF
--- a/components/GitHubSyncDialog.tsx
+++ b/components/GitHubSyncDialog.tsx
@@ -157,7 +157,7 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
     if (isOpen) {
       checkConnectionStatus();
     }
-  }, [isOpen]);
+  }, [isOpen, checkConnectionStatus]);
 
   // Check connection status
   const checkConnectionStatus = useCallback(async () => {
@@ -181,7 +181,7 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
     } finally {
       setIsLoadingStatus(false);
     }
-  }, []);
+  }, [loadRepositories]);
 
   // Load repositories from GitHub
   const loadRepositories = useCallback(async () => {

--- a/components/LinkedInImportDialog.tsx
+++ b/components/LinkedInImportDialog.tsx
@@ -76,8 +76,6 @@ export const LinkedInImportDialog: React.FC<LinkedInImportDialogProps> = ({
   const [editedSummary, setEditedSummary] = useState('');
   const [editedSkills, setEditedSkills] = useState<string[]>([]);
 
-  if (!isOpen) return null;
-
   const getStepIndex = () => STEPS.findIndex((s) => s.id === currentStep);
 
   // Handle OAuth flow
@@ -393,6 +391,9 @@ export const LinkedInImportDialog: React.FC<LinkedInImportDialogProps> = ({
     e.stopPropagation();
     folderInputRef.current?.click();
   };
+
+  // Conditional render - must be after all hooks
+  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-in fade-in duration-200">

--- a/components/VersionHistory.tsx
+++ b/components/VersionHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { ResumeVersion } from '../types';
 import { listResumeVersions, restoreResumeVersion } from '../utils/api-client';
 import { getVersionTimeAgo, formatVersionNumber } from '../utils/versioning';
@@ -19,9 +19,9 @@ const VersionHistory: React.FC<VersionHistoryProps> = ({ resumeId, onRestore }) 
 
   useEffect(() => {
     loadVersions();
-  }, [resumeId]);
+  }, [resumeId, loadVersions]);
 
-  const loadVersions = async () => {
+  const loadVersions = useCallback(async () => {
     try {
       setLoading(true);
       const data = await listResumeVersions(resumeId);
@@ -32,7 +32,7 @@ const VersionHistory: React.FC<VersionHistoryProps> = ({ resumeId, onRestore }) 
     } finally {
       setLoading(false);
     }
-  };
+  }, [resumeId]);
 
   const handleRestore = async (version: ResumeVersion) => {
     if (


### PR DESCRIPTION
## Description
Fixes GitHub issue #728 by addressing missing React hooks dependencies in multiple components.

## Changes Made
- **GitHubSyncDialog.tsx**: Added missing dependencies to useEffect and useCallback hooks
- **LinkedInImportDialog.tsx**: Fixed rules-of-hooks violation by moving conditional return after all hooks
- **VersionHistory.tsx**: Added loadVersions to useEffect dependency array and wrapped in useCallback

## ESLint Warnings Fixed
- components/GitHubSyncDialog.tsx:160:6 - Added checkConnectionStatus to dependency array
- components/GitHubSyncDialog.tsx:184:6 - Added loadRepositories to dependency array  
- components/LinkedInImportDialog.tsx:253:3 - Fixed conditional useEffect call (rules-of-hooks)
- components/VersionHistory.tsx:22:6 - Added loadVersions to dependency array

## Verification
Verified with: npm run lint

Closes #728