### PR TITLE
fix: Clean up Python linting warnings (#731)

### DIFF
--- a/resume-cli/cli/utils/versioning.py
+++ b/resume-cli/cli/utils/versioning.py
@@ -43,9 +43,9 @@ class ResumeVersionManager:
         Returns:
             Dictionary with version info
         """
-        # Read current resume content
+        # Read current resume content to ensure it's accessible
         with open(self.yaml_path, "r", encoding="utf-8") as f:
-            content = f.read()
+            f.read()
 
         # Get version number
         version_number = self._get_next_version_number()

--- a/resume_ai_lib/src/resume_ai_lib/ats_checker.py
+++ b/resume_ai_lib/src/resume_ai_lib/ats_checker.py
@@ -457,13 +457,13 @@ class ATSCompatibilityChecker:
         text_parts = []
 
         basics = resume_data.get("basics", {})
-        for field in ["name", "summary", "headline"]:
-            if basics.get(field):
-                text_parts.append(str(basics[field]))
+        for field_name in ["name", "summary", "headline"]:
+            if basics.get(field_name):
+                text_parts.append(str(basics[field_name]))
 
-        for field in ["work", "experience"]:
-            if field in resume_data and isinstance(resume_data[field], list):
-                for exp in resume_data[field]:
+        for section in ["work", "experience"]:
+            if section in resume_data and isinstance(resume_data[section], list):
+                for exp in resume_data[section]:
                     if isinstance(exp, dict):
                         for key in [
                             "position",

--- a/scripts/load_test_replicas.py
+++ b/scripts/load_test_replicas.py
@@ -314,7 +314,6 @@ class ReplicaLoadTester:
 
         try:
             # Try to get replica status (which uses replicas for reads)
-            start = time.time()
             response = await self.client.get(f"{self.api_url}/health/replicas")
             metric.end_time = time.time()
 
@@ -341,7 +340,6 @@ class ReplicaLoadTester:
         try:
             # This would execute a write operation (always goes to primary)
             # For now, simulate with a health check endpoint
-            start = time.time()
             response = await self.client.post(
                 f"{self.api_url}/health/check", json={"query": "write"}
             )

--- a/server.py
+++ b/server.py
@@ -746,7 +746,7 @@ async def import_linkedin_file(files: List[UploadFile] = File(...)):
                 try:
                     json_data = json.loads(content.decode("utf-8"))
                     print("DEBUG: Found valid JSON data")
-                except:
+                except json.JSONDecodeError:
                     print(f"DEBUG: Failed to parse JSON from {file.filename}")
             elif file.filename.endswith(".zip"):
                 print("DEBUG: Processing ZIP file")
@@ -891,7 +891,7 @@ def _process_linkedin_csvs(csv_files):
 
         try:
             return list(csv.DictReader(io.StringIO(content)))
-        except:
+        except csv.Error:
             return []
 
     # Map filenames to keys

--- a/tests/api_integration_tests/test_api_advanced_scenarios.py
+++ b/tests/api_integration_tests/test_api_advanced_scenarios.py
@@ -271,7 +271,7 @@ class TestDataIntegrity:
         assert response1.status_code == 200
         assert response2.status_code == 200
         # Data structure should be consistent
-        assert type(response1.json()) == type(response2.json())
+        assert type(response1.json()) is type(response2.json())
 
 
 class TestResponseConsistency:


### PR DESCRIPTION
## Summary

Fixed GitHub issue #731: Clean up Python linting warnings - unused imports

### Changes Made

1. **server.py:749** - Changed bare `except:` to `except json.JSONDecodeError:`
2. **server.py:894** - Changed bare `except:` to `except csv.Error:`
3. **tests/api_integration_tests/test_api_advanced_scenarios.py:273** - Changed `==` to `is` for type comparison
4. **resume-cli/cli/utils/versioning.py:48** - Changed `content = f.read()` to just `f.read()` (unused variable)
5. **resume_ai_lib/src/resume_ai_lib/ats_checker.py:460** - Renamed loop variable `field` to `field_name` to avoid import shadowing
6. **scripts/load_test_replicas.py:317,344** - Removed unused `start = time.time()` assignments

### Note
- E402 warnings are intentional due to sys.path modification for vendor library - these were NOT fixed
- F823 in dependencies.py:100 was already fixed (conditional assignment pattern is valid)
- F811 in cache.py:589 was already fixed (line 18 unused imports already resolved)

### Verification
- ✅ Flake8 passes with no errors for these files

Closes #731