### PR TITLE
fix: Memory leak from nested setTimeout (#754)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -129,6 +129,8 @@ function App() {
 
     setSaveStatus('saving');
 
+    let innerTimeout: ReturnType<typeof setTimeout> | null = null;
+
     const handler = setTimeout(async () => {
       try {
         await saveResumeData(resumeData);
@@ -137,7 +139,7 @@ function App() {
           console.log('Resume data saved to localStorage');
         }
 
-        setTimeout(() => setSaveStatus('idle'), 3000);
+        innerTimeout = setTimeout(() => setSaveStatus('idle'), 3000);
       } catch (error) {
         setSaveStatus('error');
         const storageError = error instanceof StorageError ? error : null;
@@ -148,11 +150,16 @@ function App() {
           type: ErrorType.STORAGE,
         });
 
-        setTimeout(() => setSaveStatus('idle'), 5000);
+        innerTimeout = setTimeout(() => setSaveStatus('idle'), 5000);
       }
     }, 1000);
 
-    return () => clearTimeout(handler);
+    return () => {
+      clearTimeout(handler);
+      if (innerTimeout) {
+        clearTimeout(innerTimeout);
+      }
+    };
   }, [resumeData, isLoaded, setSaveStatus]);
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in App.tsx caused by nested setTimeout calls that were not being properly cleaned up.

### Problem

In the useEffect responsible for auto-saving resume data to localStorage, there were nested setTimeout calls that were not being cleaned up:
- setTimeout to set saveStatus to 'idle' after 3000ms (success case)
- setTimeout to set saveStatus to 'idle' after 5000ms (error case)

Only the outer setTimeout was being cleared in the cleanup function, leaving the inner timeouts to potentially execute after the component unmounts or when dependencies change.

### Solution

- Store reference to the inner setTimeout in a variable (innerTimeout)
- Updated the cleanup function to clear both the outer and inner timeouts
- Added proper TypeScript typing using ReturnType<typeof setTimeout>

### Changes

- Modified App.tsx to properly clean up nested timeouts in the auto-save useEffect

### Testing

- Verified the fix compiles successfully with npm run build