### PR TITLE
feat: Add circuit breakers for external service calls (#822)

### DIFF
--- a/resume-api/lib/utils/__init__.py
+++ b/resume-api/lib/utils/__init__.py
@@ -9,6 +9,14 @@ from .ats_checker import (
     check_ats_compatibility,
     ATSCompatibilityReport,
 )
+from .circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+    CircuitState,
+    openai_breaker,
+    claude_breaker,
+    gemini_breaker,
+)
 
 __all__ = [
     "AITailoringUtils",
@@ -19,4 +27,10 @@ __all__ = [
     "ATSCompatibilityChecker",
     "check_ats_compatibility",
     "ATSCompatibilityReport",
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "CircuitState",
+    "openai_breaker",
+    "claude_breaker",
+    "gemini_breaker",
 ]

--- a/resume-api/lib/utils/circuit_breaker.py
+++ b/resume-api/lib/utils/circuit_breaker.py
@@ -16,7 +16,7 @@ Configuration:
 import logging
 from enum import Enum
 from typing import Optional, Callable, Any, TypeVar
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ class CircuitBreaker:
         if self.open_time is None:
             return False
 
-        elapsed = (datetime.utcnow() - self.open_time).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.open_time).total_seconds()
         return elapsed >= self.timeout
 
     def _on_success(self) -> None:
@@ -142,12 +142,12 @@ class CircuitBreaker:
 
     def _on_failure(self) -> None:
         """Handle failed call."""
-        self.last_failure_time = datetime.utcnow()
+        self.last_failure_time = datetime.now(timezone.utc)
 
         if self.state == CircuitState.HALF_OPEN:
             # Any failure in HALF_OPEN reopens circuit
             self.state = CircuitState.OPEN
-            self.open_time = datetime.utcnow()
+            self.open_time = datetime.now(timezone.utc)
             self.success_count = 0
             logger.warning(
                 f"Circuit breaker '{self.name}' failure in HALF_OPEN. "
@@ -163,7 +163,7 @@ class CircuitBreaker:
 
             if self.failure_count >= self.failure_threshold:
                 self.state = CircuitState.OPEN
-                self.open_time = datetime.utcnow()
+                self.open_time = datetime.now(timezone.utc)
                 logger.warning(
                     f"Circuit breaker '{self.name}' opened after "
                     f"{self.failure_count} failures"
@@ -174,7 +174,7 @@ class CircuitBreaker:
         if self.open_time is None:
             return self.timeout
 
-        elapsed = (datetime.utcnow() - self.open_time).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.open_time).total_seconds()
         remaining = max(0, self.timeout - elapsed)
         return int(remaining)
 

--- a/resume-api/tests/test_circuit_breaker.py
+++ b/resume-api/tests/test_circuit_breaker.py
@@ -345,19 +345,19 @@ class TestCircuitBreakerIntegration:
 
     def test_time_until_retry_calculation(self):
         """Test _time_until_retry calculates correctly."""
-        breaker = CircuitBreaker(name="test", timeout=60)
+        breaker = CircuitBreaker(name="test", timeout=60, failure_threshold=1)
         func = Mock(side_effect=Exception("error"))
 
         with pytest.raises(Exception):
             breaker.call(func)
 
-        # Open the circuit
+        # Open the circuit (failure_threshold=1)
         assert breaker.state == CircuitState.OPEN
 
         # Mock the open_time to test calculation
         import datetime
 
-        breaker.open_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=30)
+        breaker.open_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=30)
 
         remaining = breaker._time_until_retry()
         assert 25 <= remaining <= 35  # Allow some tolerance for execution time


### PR DESCRIPTION
Implements circuit breakers for external AI service calls to handle failures gracefully.

Changes:
- Exported circuit breaker in lib/utils/__init__.py
- Fixed deprecated datetime.utcnow() with timezone-aware datetime.now(timezone.utc)
- Fixed test for failure_threshold and timezone-aware datetime

Existing implementation includes:
- CircuitBreaker class with CLOSED, OPEN, HALF_OPEN states
- Pre-configured thresholds (5 failures to open, 2 successes to close, 60s timeout)
- Global instances: openai_breaker, claude_breaker, gemini_breaker
- Integration with AI providers in lib/utils/ai.py
- Tests: 21 tests covering state transitions, thresholds, timeouts, exceptions

Closes #822
