### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 
 **Learning:** The copy button for newly generated API keys lacked an `aria-label`, meaning screen readers would read it as a blank button after it was copied. The `ShareDialog` provided a better model for this interaction.
 **Action:** When implementing interactive buttons that change state (like copy buttons), always ensure the `aria-label` dynamically updates to reflect the new state (e.g. from "Copy API key" to "API key copied") to give screen reader users clear, immediate feedback of the action resolving.
+## 2026-03-08 - Added ARIA labels to icon-only buttons
+**Learning:** Found multiple instances where icon-only buttons lacked `aria-label` attributes and the inner Material Symbol `<span>` elements lacked `aria-hidden="true"`. This is a common pattern in the repository that reduces accessibility for screen reader users. Dynamic aria-labels (like "Expand details" vs "Collapse details") enhance context.
+**Action:** Always ensure icon-only buttons have descriptive `aria-label`s and hide decorative ligature icons with `aria-hidden="true"`.

--- a/components/TemplateSelector.tsx
+++ b/components/TemplateSelector.tsx
@@ -166,11 +166,17 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                     <p className="text-sm text-slate-500 mt-1">{template.description}</p>
                   </div>
                 </div>
-                <button className="p-2 text-slate-400 hover:text-slate-600">
+                <button
+                  className="p-2 text-slate-400 hover:text-slate-600"
+                  aria-label={
+                    expandedTemplate === template.name ? 'Collapse details' : 'Expand details'
+                  }
+                >
                   <span
                     className={`material-symbols-outlined transition-transform ${
                       expandedTemplate === template.name ? 'rotate-180' : ''
                     }`}
+                    aria-hidden="true"
                   >
                     expand_more
                   </span>

--- a/pages/Invoices.tsx
+++ b/pages/Invoices.tsx
@@ -87,8 +87,14 @@ const Invoices: React.FC = () => {
           <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg mb-6 flex items-center gap-2">
             <span className="material-symbols-outlined text-red-500">error</span>
             <span className="text-sm font-semibold">{error}</span>
-            <button onClick={() => setError(null)} className="ml-2 text-red-500 hover:text-red-700">
-              <span className="material-symbols-outlined text-[20px]">close</span>
+            <button
+              onClick={() => setError(null)}
+              className="ml-2 text-red-500 hover:text-red-700"
+              aria-label="Dismiss error"
+            >
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                close
+              </span>
             </button>
           </div>
         )}
@@ -157,12 +163,23 @@ const Invoices: React.FC = () => {
                           onClick={() => handleDownload(invoice)}
                           className="text-slate-400 hover:text-primary-600 transition-colors"
                           title="Download PDF"
+                          aria-label="Download PDF"
                         >
-                          <span className="material-symbols-outlined text-[20px]">download</span>
+                          <span
+                            className="material-symbols-outlined text-[20px]"
+                            aria-hidden="true"
+                          >
+                            download
+                          </span>
                         </button>
                       ) : (
                         <span className="text-slate-300">
-                          <span className="material-symbols-outlined text-[20px]">download</span>
+                          <span
+                            className="material-symbols-outlined text-[20px]"
+                            aria-hidden="true"
+                          >
+                            download
+                          </span>
                         </span>
                       )}
                     </td>

--- a/pages/Teams.tsx
+++ b/pages/Teams.tsx
@@ -184,8 +184,11 @@ const Teams: React.FC = () => {
               onClick={handleBackToList}
               className="p-2 hover:bg-slate-100 rounded-lg transition-colors"
               title="Back to teams"
+              aria-label="Back to teams"
             >
-              <span className="material-symbols-outlined text-slate-600">arrow_back</span>
+              <span className="material-symbols-outlined text-slate-600" aria-hidden="true">
+                arrow_back
+              </span>
             </button>
           )}
           <h2 className="text-slate-800 font-bold text-xl">
@@ -198,12 +201,19 @@ const Teams: React.FC = () => {
               onClick={handleCreateTeam}
               className="px-4 py-2 rounded-lg bg-primary-600 text-white font-bold text-sm hover:bg-primary-700 transition-colors shadow-lg shadow-primary-600/20 flex items-center gap-2"
             >
-              <span className="material-symbols-outlined text-[18px]">add</span>
+              <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                add
+              </span>
               Create Team
             </button>
           )}
-          <button className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <button
+            className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative"
+            aria-label="Notifications"
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </button>
           <div


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons and `aria-hidden="true"` to inner Material Symbol ligatures across `TemplateSelector`, `Teams`, and `Invoices` components.
🎯 Why: Enhances screen reader accessibility by providing descriptive text for interactive elements that only have visual icons.
♿ Accessibility: Improved semantic markup for screen readers, ensuring buttons are clearly identifiable (e.g., distinguishing "Expand details" from "Collapse details" dynamically).
📸 Tested via `pnpm test` and verified no regressions. Line changes strictly kept under 50 lines.

---
*PR created automatically by Jules for task [17265561250288718986](https://jules.google.com/task/17265561250288718986) started by @anchapin*