### PR TITLE
fix: escape backticks in grep pattern for AGENTS.md validation

### DIFF
--- a/.github/workflows/agents-validation.yml
+++ b/.github/workflows/agents-validation.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Validate AGENTS.md has code examples
         if: steps.check_file.outputs.exists == 'true'
         run: |
-          # Check for code blocks
-          if ! grep -q "```" AGENTS.md; then
+          # Check for code blocks (escape backticks for literal match)
+          if ! grep -q '\`\`\`' AGENTS.md; then
             echo "error=AGENTS.md must contain code examples" >> $GITHUB_OUTPUT
             exit 1
           fi


### PR DESCRIPTION
This PR fixes the AGENTS.md validation workflow that was failing with:

```
unexpected EOF while looking for matching ```
```

The grep pattern ``` was being interpreted as shell command substitution even inside double quotes, causing the validation to fail.

**Root Cause:** In bash, backticks inside double quotes are still interpreted as command substitution. The fix is to escape the backticks with backslashes for literal matching.

**Changes:**
- Escape backticks in grep pattern: `grep -q '```' AGENTS.md`

This fix enables PRs #889 and #890 to pass validation.