### PR TITLE
🎨 Palette: Add ARIA labels to webhook action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,7 @@
 ## 2026-03-08 - Added ARIA labels to icon-only buttons
 **Learning:** Found multiple instances where icon-only buttons lacked `aria-label` attributes and the inner Material Symbol `<span>` elements lacked `aria-hidden="true"`. This is a common pattern in the repository that reduces accessibility for screen reader users. Dynamic aria-labels (like "Expand details" vs "Collapse details") enhance context.
 **Action:** Always ensure icon-only buttons have descriptive `aria-label`s and hide decorative ligature icons with `aria-hidden="true"`.
+
+## 2026-03-09 - Ensure aria-hidden for ligature icons
+**Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
+**Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.

--- a/components/DeliveryLogs.tsx
+++ b/components/DeliveryLogs.tsx
@@ -118,8 +118,11 @@ const DeliveryLogs: React.FC<DeliveryLogsProps> = ({ webhookId, onClose }) => {
         <button
           onClick={onClose}
           className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+          aria-label="Close delivery logs"
         >
-          <span className="material-symbols-outlined">close</span>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
         </button>
       </div>
 
@@ -218,8 +221,9 @@ const DeliveryLogs: React.FC<DeliveryLogsProps> = ({ webhookId, onClose }) => {
                         disabled={retryingDeliveryId === delivery.id}
                         className="p-2 text-slate-500 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
                         title="Retry delivery"
+                        aria-label="Retry delivery"
                       >
-                        <span className="material-symbols-outlined text-[20px]">
+                        <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                           {retryingDeliveryId === delivery.id ? 'progress_activity' : 'refresh'}
                         </span>
                       </button>
@@ -231,8 +235,11 @@ const DeliveryLogs: React.FC<DeliveryLogsProps> = ({ webhookId, onClose }) => {
                       }}
                       className="p-2 text-slate-500 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
                       title="View payload"
+                      aria-label="View payload"
                     >
-                      <span className="material-symbols-outlined text-[20px]">code</span>
+                      <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                        code
+                      </span>
                     </button>
                   </div>
                 </div>

--- a/components/WebhookForm.tsx
+++ b/components/WebhookForm.tsx
@@ -133,8 +133,11 @@ const WebhookForm: React.FC<WebhookFormProps> = ({ webhook, onSuccess, onCancel 
         <button
           onClick={onCancel}
           className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+          aria-label="Close form"
         >
-          <span className="material-symbols-outlined">close</span>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
         </button>
       </div>
 

--- a/components/WebhookList.tsx
+++ b/components/WebhookList.tsx
@@ -202,8 +202,9 @@ const WebhookList: React.FC<WebhookListProps> = ({ onEdit, onViewDeliveries, onR
                     disabled={testingWebhookId === webhook.id}
                     className="p-2 text-slate-500 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
                     title="Test webhook"
+                    aria-label="Test webhook"
                   >
-                    <span className="material-symbols-outlined text-[20px]">
+                    <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                       {testingWebhookId === webhook.id ? 'progress_activity' : 'play_arrow'}
                     </span>
                   </button>
@@ -211,23 +212,32 @@ const WebhookList: React.FC<WebhookListProps> = ({ onEdit, onViewDeliveries, onR
                     onClick={() => onViewDeliveries(webhook.id)}
                     className="p-2 text-slate-500 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
                     title="View deliveries"
+                    aria-label="View deliveries"
                   >
-                    <span className="material-symbols-outlined text-[20px]">history</span>
+                    <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                      history
+                    </span>
                   </button>
                   <button
                     onClick={() => onEdit(webhook)}
                     className="p-2 text-slate-500 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
                     title="Edit webhook"
+                    aria-label="Edit webhook"
                   >
-                    <span className="material-symbols-outlined text-[20px]">edit</span>
+                    <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                      edit
+                    </span>
                   </button>
                   <button
                     onClick={() => handleDeleteWebhook(webhook.id, webhook.description || '')}
                     disabled={deletingWebhookId === webhook.id}
                     className="p-2 text-slate-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                     title="Delete webhook"
+                    aria-label="Delete webhook"
                   >
-                    <span className="material-symbols-outlined text-[20px]">delete</span>
+                    <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                      delete
+                    </span>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
💡 What: Added `aria-label`s to 8 icon-only buttons across webhook-related components (`WebhookList.tsx`, `WebhookForm.tsx`, `DeliveryLogs.tsx`) and set `aria-hidden="true"` on their respective ligature icons.
🎯 Why: Without ARIA labels, screen readers announce these buttons as "button" or read their internal ligature text (e.g., "close", "history", "edit"), making the webhook management interface completely inaccessible to visually impaired users.
📸 Before/After: Visuals remain unchanged, but the accessibility tree now properly identifies the actions.
♿ Accessibility: Significant improvement for screen reader navigation in webhook settings.

---
*PR created automatically by Jules for task [11617101826308863697](https://jules.google.com/task/11617101826308863697) started by @anchapin*