### PR TITLE
🎨 Palette: Add aria-hidden to decorative Material Icons in Editor

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,8 @@
 
 **Learning:** Common pattern of `div` with `onClick` used for navigation/interactive elements instead of semantic `<button>` or `<a>` tags. This breaks keyboard accessibility and screen reader support.
 **Action:** Always check interactive elements for semantic HTML tags. Replace `div` with `button` or `a` and ensure `type="button"` for non-submit buttons. Add `aria-label` where text is not descriptive enough, and `aria-current` for navigation links.
+
+## 2024-05-23 - Material Symbols Screen Reader Accessibility
+
+**Learning:** Material Symbols (using ligatures like `<span className="material-symbols-outlined">icon_name</span>`) are often announced literally by screen readers (e.g., "icon name") when used decoratively alongside text, creating redundant and confusing auditory experiences. Additionally, icons acting as loading spinners (`animate-spin`) lack proper container semantics to announce their state.
+**Action:** Always add `aria-hidden="true"` to Material Symbol `<span>` elements used decoratively alongside visible text. For icon-only loading states (spinners) and status indicators, ensure the parent container has `role="status"` and `aria-live="polite"`.

--- a/components/editor/EditorActions.tsx
+++ b/components/editor/EditorActions.tsx
@@ -61,7 +61,9 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
         className="flex items-center gap-2 px-4 h-10 rounded-lg border border-slate-300 bg-white text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
         title="Undo (Ctrl+Z)"
       >
-        <span className="material-symbols-outlined text-lg">undo</span>
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
+          undo
+        </span>
         <span className="hidden sm:inline">Undo</span>
       </button>
       <button
@@ -70,7 +72,9 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
         className="flex items-center gap-2 px-4 h-10 rounded-lg border border-slate-300 bg-white text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
         title="Redo (Ctrl+Y or Ctrl+Shift+Z)"
       >
-        <span className="material-symbols-outlined text-lg">redo</span>
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
+          redo
+        </span>
         <span className="hidden sm:inline">Redo</span>
       </button>
       <button
@@ -78,7 +82,9 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
         className="flex items-center gap-2 px-4 h-10 rounded-lg border border-slate-300 bg-white text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm relative"
         title="View comments"
       >
-        <span className="material-symbols-outlined text-lg">chat_bubble_outline</span>
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
+          chat_bubble_outline
+        </span>
         <span className="hidden sm:inline">Comments</span>
         {unresolvedCommentCount > 0 && (
           <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
@@ -91,7 +97,9 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
         className="flex items-center gap-2 px-4 h-10 rounded-lg border border-slate-300 bg-white text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm"
         title="View version history"
       >
-        <span className="material-symbols-outlined text-lg">history</span>
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
+          history
+        </span>
         <span className="hidden sm:inline">History</span>
       </button>
       <button
@@ -99,7 +107,9 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
         className="flex items-center gap-2 px-4 h-10 rounded-lg border border-slate-300 bg-white text-slate-700 font-bold text-sm hover:bg-slate-50 transition-colors shadow-sm"
         title="Save as new version"
       >
-        <span className="material-symbols-outlined text-lg">save</span>
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
+          save
+        </span>
         <span className="hidden sm:inline">Save Version</span>
       </button>
       <button
@@ -110,7 +120,7 @@ export const EditorActions: React.FC<EditorActionsProps> = ({
             : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
         }`}
       >
-        <span className="material-symbols-outlined text-lg">
+        <span className="material-symbols-outlined text-lg" aria-hidden="true">
           {showPreview ? 'visibility_off' : 'visibility'}
         </span>
         {showPreview ? 'Hide Preview' : 'Preview'}

--- a/pages/Editor.tsx
+++ b/pages/Editor.tsx
@@ -112,15 +112,8 @@ const Editor = () => {
 
   // Undo/Redo functionality using useHistory hook
   const MAX_HISTORY = 50;
-  const {
-    history,
-    historyIndex,
-    canUndo,
-    canRedo,
-    addToHistory,
-    undo,
-    redo,
-  } = useHistory<SimpleResumeData>(resumeData, { maxHistory: MAX_HISTORY, trackInitialState: false });
+  const { history, historyIndex, canUndo, canRedo, addToHistory, undo, redo } =
+    useHistory<SimpleResumeData>(resumeData, { maxHistory: MAX_HISTORY, trackInitialState: false });
 
   // Wrap setResumeData to track history
   const trackedUpdate = useCallback(
@@ -741,6 +734,8 @@ const Editor = () => {
                 Edit Professional Profile
               </h1>
               <p
+                role="status"
+                aria-live="polite"
                 className={`font-medium text-sm flex items-center gap-1 ${
                   saveStatus === 'error'
                     ? 'text-red-600'
@@ -753,31 +748,44 @@ const Editor = () => {
               >
                 {saveStatus === 'saving' && (
                   <>
-                    <span className="material-symbols-outlined text-sm animate-spin">sync</span>
+                    <span
+                      className="material-symbols-outlined text-sm animate-spin"
+                      aria-hidden="true"
+                    >
+                      sync
+                    </span>
                     Saving...
                   </>
                 )}
                 {saveStatus === 'saved' && (
                   <>
-                    <span className="material-symbols-outlined text-sm">check_circle</span>
+                    <span className="material-symbols-outlined text-sm" aria-hidden="true">
+                      check_circle
+                    </span>
                     Saved
                   </>
                 )}
                 {saveStatus === 'error' && (
                   <>
-                    <span className="material-symbols-outlined text-sm">error</span>
+                    <span className="material-symbols-outlined text-sm" aria-hidden="true">
+                      error
+                    </span>
                     Save failed
                   </>
                 )}
                 {saveStatus === 'idle' && lastSaved && (
                   <>
-                    <span className="material-symbols-outlined text-sm">check_circle</span>
+                    <span className="material-symbols-outlined text-sm" aria-hidden="true">
+                      check_circle
+                    </span>
                     Saved {getTimeSince(lastSaved)} ago
                   </>
                 )}
                 {saveStatus === 'idle' && !lastSaved && (
                   <>
-                    <span className="material-symbols-outlined text-sm">edit</span>
+                    <span className="material-symbols-outlined text-sm" aria-hidden="true">
+                      edit
+                    </span>
                     Changes not yet saved
                   </>
                 )}


### PR DESCRIPTION
### 💡 What:
Added `aria-hidden="true"` to decorative Material Icons in `pages/Editor.tsx` and `components/editor/EditorActions.tsx`. Additionally, added `role="status"` and `aria-live="polite"` to the container that displays the save status in the editor. Appended a new learning about icon accessibility to `.jules/palette.md`.

### 🎯 Why:
Material Symbol icons implemented as text ligatures (e.g., `<span class="material-symbols-outlined">save</span>`) are often literally announced by screen readers (e.g., "save"), which is redundant and confusing when placed next to visible text like "Save Version". Hiding these decorative icons improves the auditory experience. Furthermore, the save status text dynamically updates ("Saving...", "Saved"), so wrapping it in an `aria-live="polite"` container ensures those updates are proactively announced to assistive technology without interrupting the user.

### 📸 Before/After:
*Visual change: None.* The updates are purely semantic HTML attribute additions.

### ♿ Accessibility:
- Prevented redundant screen reader readouts of decorative icon ligature text in the Editor toolbar.
- Ensures the dynamic "saving..." state changes are properly announced.

---
*PR created automatically by Jules for task [6160728125744365691](https://jules.google.com/task/6160728125744365691) started by @anchapin*

## Summary by Sourcery

Improve accessibility semantics for icons and save status messaging in the Editor.

Enhancements:
- Mark decorative Material Symbol icons in the Editor header and toolbar as aria-hidden to avoid redundant screen reader announcements.
- Add an aria-live polite status region for dynamic save status messaging in the Editor.
- Document accessibility learnings and guidelines for Material Symbols usage in the palette knowledge base.