### PR TITLE
fix: implement Stripe webhook verification (#1008)

### DIFF
--- a/resume-api/lib/stripe.py
+++ b/resume-api/lib/stripe.py
@@ -177,12 +177,7 @@ class StripeService:
         self, payload: bytes, signature: str, webhook_secret: str
     ) -> stripe.Event:
         """Verify Stripe webhook signature."""
-        # TODO(#1008): Implement with Stripe Webhooks API
-        # For now, parse the payload without verification
-        import json
-
-        event_data = json.loads(payload.decode("utf-8"))
-        return stripe.Event.construct_from(event_data, stripe.api_key)
+        return stripe.Webhook.construct_event(payload, signature, webhook_secret)
 
 
 # Singleton instance

--- a/resume-api/tests/test_billing.py
+++ b/resume-api/tests/test_billing.py
@@ -11,6 +11,8 @@ Tests cover:
 
 import pytest
 import pytest_asyncio
+from unittest.mock import patch, MagicMock
+import stripe
 
 from database import (
     Subscription,
@@ -473,3 +475,39 @@ async def test_stripe_service_check_usage_limits_ai_tailoring(test_user_id):
     assert result["allowed"] is True
     assert "limit" in result
     assert "remaining" in result
+
+
+@pytest.mark.asyncio
+async def test_verify_webhook_signature_success():
+    """Test successful webhook signature verification."""
+    from lib.stripe import stripe_service
+
+    payload = b'{"id": "evt_test", "type": "checkout.session.completed"}'
+    signature = "whsec_test_sig"
+    secret = "whsec_test_secret"
+
+    with patch("stripe.Webhook.construct_event") as mock_construct:
+        mock_construct.return_value = {"id": "evt_test", "type": "checkout.session.completed"}
+
+        event = stripe_service.verify_webhook_signature(payload, signature, secret)
+
+        assert event["id"] == "evt_test"
+        mock_construct.assert_called_once_with(payload, signature, secret)
+
+
+@pytest.mark.asyncio
+async def test_verify_webhook_signature_invalid():
+    """Test failed webhook signature verification."""
+    from lib.stripe import stripe_service
+
+    payload = b'invalid'
+    signature = "invalid"
+    secret = "secret"
+
+    with patch("stripe.Webhook.construct_event") as mock_construct:
+        mock_construct.side_effect = stripe.error.SignatureVerificationError(
+            "Invalid signature", "sig_header"
+        )
+
+        with pytest.raises(stripe.error.SignatureVerificationError):
+            stripe_service.verify_webhook_signature(payload, signature, secret)


### PR DESCRIPTION
Fixes #1008

## Summary by Sourcery

Verify Stripe webhook signatures using the official Webhooks API and add coverage for successful and invalid signature handling.

Bug Fixes:
- Enable proper verification of Stripe webhook signatures instead of blindly trusting payloads.

Tests:
- Add tests for successful and failed Stripe webhook signature verification using mocked Stripe Webhook API.