### PR TITLE
test: fix worker timeout issues in vitest (#1046)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,16 @@ export default defineConfig({
     globals: true,
     setupFiles: './vitest.setup.ts',
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache', 'tests/e2e/**', 'tests/visual/**'],
+    // Worker configuration to prevent timeouts
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    // Increase timeout for slow tests
+    testTimeout: 30000,
+    hookTimeout: 30000,
     // Track test results for flaky test detection
     onConsoleLog: (type, message) => {
       // Track console output for debugging


### PR DESCRIPTION
Closes #1046

- Added pool: 'forks' for more stable test execution
- Added singleFork option to prevent parallel test issues
- Increased testTimeout and hookTimeout to 30000ms
- This fixes intermittent timeout failures in CI

## Summary by Sourcery

Stabilize Vitest execution by adjusting worker configuration and timeouts to reduce intermittent test timeouts.

Tests:
- Configure Vitest to use fork-based workers with a single fork to avoid parallel execution issues.
- Increase global test and hook timeouts to accommodate slower-running tests and reduce flaky timeouts in CI.