### PR TITLE
🛡️ Sentinel: [HIGH] Remove unsafe-eval from CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,7 @@
 **Vulnerability:** The `is_ecryptfs_path` function in `resume-api/lib/utils/ecryptfs_utils.py` used `os.popen` to execute a shell command with unsanitized user input (`path`), leading to a critical command injection vulnerability.
 **Learning:** Shell-based command execution (`os.popen`, `os.system`, `subprocess.run(shell=True)`) combined with string interpolation is inherently dangerous and must be avoided.
 **Prevention:** Always use `subprocess.run` (or similar) with an argument list rather than a single string, and ensure `shell=False` (which is the default) to prevent the shell from interpreting meta-characters.
+## 2026-03-13 - [CSP unsafe-eval Removed]
+**Vulnerability:** The Content Security Policy (CSP) `script-src` directive included `unsafe-eval`, allowing the execution of strings as code (e.g., via `eval()`, `setTimeout(string)`).
+**Learning:** Including `unsafe-eval` in the CSP significantly increases the risk of Cross-Site Scripting (XSS) attacks by allowing an attacker to execute malicious strings as scripts.
+**Prevention:** Remove `unsafe-eval` from the `script-src` directive to restrict script execution to only explicitly trusted sources.

--- a/resume-api/main.py
+++ b/resume-api/main.py
@@ -74,7 +74,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Content Security Policy
         csp = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            "script-src 'self' 'unsafe-inline'; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: https:; "
             "font-src 'self' data:; "

--- a/resume-api/tests/test_security_headers.py
+++ b/resume-api/tests/test_security_headers.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_csp_header_no_unsafe_eval():
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+
+    csp_header = response.headers.get("Content-Security-Policy")
+    assert csp_header is not None
+    assert "unsafe-eval" not in csp_header
+    assert "script-src 'self' 'unsafe-inline';" in csp_header


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Content-Security-Policy `script-src` directive included `unsafe-eval`.
🎯 Impact: This allowed the execution of strings as scripts, leading to potential Cross-Site Scripting (XSS) attacks.
🔧 Fix: Removed `unsafe-eval` from the CSP header in `resume-api/main.py`.
✅ Verification: Added a test `resume-api/tests/test_security_headers.py` and ran the pytest test suite to confirm the `Content-Security-Policy` header is correctly set without `unsafe-eval`. Also ran frontend tests.

---
*PR created automatically by Jules for task [1739381625769024385](https://jules.google.com/task/1739381625769024385) started by @anchapin*