### PR TITLE
🎨 Palette: Improve ActivityFeed accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-03-11 - Material Symbol Ligature Accessibility
 **Learning:** Material Symbol icons implemented as text ligatures (e.g., <span ...>close</span>) require aria-hidden='true' to prevent screen readers from announcing the ligature text ('close').
 **Action:** Always add aria-hidden='true' to ligature-based icon elements and ensure the parent interactive element has a descriptive aria-label.
+
+## $(date +%Y-%m-%d) - Add Accessible Loading State to ActivityFeed
+**Learning:** Icon-only loading states (like simple Material Symbol spinners) are completely invisible to screen readers unless explicitly given an accessible role and text. Also, declarative empty states using Material Symbols need to be hidden from screen readers to prevent redundant reading.
+**Action:** Always wrap loading spinners in a `div` with `role="status"` and `aria-live="polite"`, include `.sr-only` descriptive text inside it, and mark decorative ligature icons with `aria-hidden="true"`.

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -90,10 +90,14 @@ interface ActivityFeedProps {
 const ActivityFeed: React.FC<ActivityFeedProps> = React.memo(({ activities, loading }) => {
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <span className="material-symbols-outlined animate-spin text-primary-600 text-4xl">
+      <div className="flex items-center justify-center py-8" role="status" aria-live="polite">
+        <span
+          className="material-symbols-outlined animate-spin text-primary-600 text-4xl"
+          aria-hidden="true"
+        >
           progress_activity
         </span>
+        <span className="sr-only">Loading activity feed...</span>
       </div>
     );
   }
@@ -101,7 +105,9 @@ const ActivityFeed: React.FC<ActivityFeedProps> = React.memo(({ activities, load
   if (activities.length === 0) {
     return (
       <div className="text-center py-8 bg-slate-50 rounded-xl">
-        <span className="material-symbols-outlined text-slate-300 text-6xl mb-4">history</span>
+        <span className="material-symbols-outlined text-slate-300 text-6xl mb-4" aria-hidden="true">
+          history
+        </span>
         <p className="text-slate-500 font-medium mb-2">No activity yet</p>
         <p className="text-slate-400 text-sm">Recent team actions will appear here</p>
       </div>
@@ -124,7 +130,12 @@ const ActivityFeed: React.FC<ActivityFeedProps> = React.memo(({ activities, load
             <div key={activity.id} className={`relative flex gap-4 ${isLast ? '' : 'mb-4'}`}>
               {/* Timeline dot */}
               <div className="w-10 h-10 rounded-full bg-white border-2 border-slate-200 flex items-center justify-center flex-shrink-0 z-10">
-                <span className={`material-symbols-outlined text-[20px] ${color}`}>{icon}</span>
+                <span
+                  className={`material-symbols-outlined text-[20px] ${color}`}
+                  aria-hidden="true"
+                >
+                  {icon}
+                </span>
               </div>
 
               {/* Activity content */}


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the `ActivityFeed` component by adding ARIA attributes to the loading spinner and empty state icons.
🎯 **Why:** The icon-only loading state was completely invisible to screen readers, meaning visually impaired users wouldn't know the feed was loading. Also, decorative Material Symbols were being announced literally by their ligature names (e.g., "progress activity", "history"), which is confusing.
♿ **Accessibility:**
- Added `role="status"` and `aria-live="polite"` to the loading container.
- Added visually hidden screen reader text "Loading activity feed...".
- Added `aria-hidden="true"` to decorative Material Symbol ligature `span`s to mark them as decorative.

---
*PR created automatically by Jules for task [5490046644330453408](https://jules.google.com/task/5490046644330453408) started by @anchapin*