### PR TITLE
fix: upgrade black to 26.3.1 to resolve CVE-2026-32274 (#1069)

### DIFF
--- a/resume-api/requirements.txt
+++ b/resume-api/requirements.txt
@@ -34,7 +34,7 @@ pytest==9.0.2
 pytest-asyncio==1.3.0
 
 # Development Tools
-black==26.1.0
+black==26.3.1
 flake8==7.3.0
 mypy==1.19.1
 


### PR DESCRIPTION
## Summary

This PR resolves CVE-2026-32274 by upgrading the black dependency from version 26.1.0 to 26.3.1.

## Changes

- Updated : black==26.1.0 → black==26.3.1

## Testing

- Verified no other references to black==26.1.0 exist in the codebase

## Related Issue

Fixes #1069