### PR TITLE
🎨 Palette: Hide Button loading spinner from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2026-03-11 - Material Symbol Ligature Screen Reader Noise
 **Learning:** Even within an interactive element with a proper `aria-label`, the ligature text (e.g., "delete") of a Material Symbol `<span>` is sometimes still announced by certain screen readers, causing repetitive or confusing announcements.
 **Action:** Always add `aria-hidden="true"` to Material Symbol `<span>` elements acting as ligatures to strictly enforce their decorative status and let the parent interactive element handle the accessible name.
+## 2026-03-18 - Added aria-hidden to Button loading spinner
+**Learning:** Loading spinners and decorative icons implemented using Material Symbol ligatures (e.g., `progress_activity`) inside UI `<button>` components must explicitly include `aria-hidden="true"` to prevent screen readers from redundantly announcing the ligature text alongside the button text.
+**Action:** Always add `aria-hidden="true"` to `<span className="material-symbols-outlined">` elements when they are used purely for decorative purposes or accompanied by text context in a button.

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -48,7 +48,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button ref={ref} className={combinedClassName} disabled={disabled || isLoading} {...props}>
         {isLoading && (
-          <span className="material-symbols-outlined animate-spin text-[20px]">
+          <span className="material-symbols-outlined animate-spin text-[20px]" aria-hidden="true">
             progress_activity
           </span>
         )}


### PR DESCRIPTION
## 💡 What
Added `aria-hidden="true"` to the loading spinner element (`<span className="material-symbols-outlined animate-spin">`) inside the global `<Button>` component.

## 🎯 Why
When `isLoading` is true, the Button component renders a Material Symbol ligature (`progress_activity`) as a visual spinner. Without `aria-hidden="true"`, screen readers will explicitly read out the text "progress activity", which is confusing when it's placed next to an existing loading text string (like "Creating account..."). Hiding the purely decorative icon provides a much cleaner, less redundant experience for users relying on assistive technologies.

## ♿ Accessibility
- Improves screen reader clarity by hiding decorative loading icons from the accessibility tree, making it so only the actual button text (e.g., "Creating account...") is read aloud.

---
*PR created automatically by Jules for task [8161948670612697262](https://jules.google.com/task/8161948670612697262) started by @anchapin*

## Summary by Sourcery

Hide decorative loading spinner icons in the global Button component from assistive technologies to improve screen reader behavior.

Bug Fixes:
- Prevent Button loading spinner ligature text from being announced by screen readers when isLoading is true.

Documentation:
- Document the accessibility guideline to mark Material Symbol ligature-based loading spinners and decorative icons as aria-hidden in palette notes.