### PR TITLE
🎨 Palette: Hide Button Loading Spinner Ligature from Screen Readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2026-03-11 - Material Symbol Ligature Screen Reader Noise
 **Learning:** Even within an interactive element with a proper `aria-label`, the ligature text (e.g., "delete") of a Material Symbol `<span>` is sometimes still announced by certain screen readers, causing repetitive or confusing announcements.
 **Action:** Always add `aria-hidden="true"` to Material Symbol `<span>` elements acting as ligatures to strictly enforce their decorative status and let the parent interactive element handle the accessible name.
+## 2026-03-23 - Material Symbol Loading Spinners
+**Learning:** Loading spinners implemented as Material Symbol ligatures inside interactive elements (like Buttons) must include `aria-hidden="true"`. Otherwise, screen readers may announce the raw ligature text (e.g., "progress activity") alongside the element's accessible name or state, creating a confusing and redundant auditory experience.
+**Action:** Always verify that decorative or animated ligature icons within components have `aria-hidden="true"` applied to prevent them from being read aloud.

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -48,7 +48,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button ref={ref} className={combinedClassName} disabled={disabled || isLoading} {...props}>
         {isLoading && (
-          <span className="material-symbols-outlined animate-spin text-[20px]">
+          <span className="material-symbols-outlined animate-spin text-[20px]" aria-hidden="true">
             progress_activity
           </span>
         )}


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the Material Symbol `<span>` used for the loading spinner (`progress_activity`) in the `<Button />` component.
🎯 Why: Screen readers would otherwise read the raw ligature text ("progress activity") aloud when the button is in a loading state. Since this is a decorative/animated visual indicator, it should be hidden from assistive technologies to avoid a confusing auditory experience.
♿ Accessibility: Prevents screen readers from announcing redundant ligature text inside buttons.

---
*PR created automatically by Jules for task [6301733718048219225](https://jules.google.com/task/6301733718048219225) started by @anchapin*

## Summary by Sourcery

Hide decorative loading spinner ligature icons in buttons from assistive technologies to avoid redundant screen reader announcements.

Enhancements:
- Mark the Material Symbol-based loading spinner in the Button component as aria-hidden to prevent its ligature text from being announced by screen readers.

Documentation:
- Add a palette entry documenting the accessibility requirement to apply aria-hidden to Material Symbol loading spinners used as decorative ligatures.