### PR TITLE
🎨 Palette: Add ARIA labels to ActivityFeed icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,6 +15,7 @@
 ## 2026-03-11 - Material Symbol Ligature Screen Reader Noise
 **Learning:** Even within an interactive element with a proper `aria-label`, the ligature text (e.g., "delete") of a Material Symbol `<span>` is sometimes still announced by certain screen readers, causing repetitive or confusing announcements.
 **Action:** Always add `aria-hidden="true"` to Material Symbol `<span>` elements acting as ligatures to strictly enforce their decorative status and let the parent interactive element handle the accessible name.
-## 2026-03-26 - SVG Icon-Only Button Accessibility
-**Learning:** Icon-only buttons using SVG elements must have an `aria-label` on the `<button>` element describing the action, and the inner `<svg>` element must have `aria-hidden="true"` to prevent screen readers from announcing it incorrectly or redundantly. Dynamic lists should include item-specific context in the label.
-**Action:** Always verify that icon-only buttons include descriptive `aria-label`s (dynamic if inside lists) and hide decorative SVGs using `aria-hidden="true"`.
+
+## 2024-05-19 - Icon-Only Button Accessibility in ActivityFeed
+**Learning:** Decorative icons and loading spinners implemented using Material Symbols text ligatures (e.g., `<span class="material-symbols-outlined">progress_activity</span>`) inside visually unlabeled interactive elements are announced literally by screen readers.
+**Action:** When adding generic icon buttons or states without visible text, always include a descriptive `aria-label` or `role="status"` on the container and `aria-hidden="true"` on the underlying `<svg>` or `<span>` icon element to prevent redundant ligature text announcement.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2026-03-11 - Material Symbol Ligature Screen Reader Noise
 **Learning:** Even within an interactive element with a proper `aria-label`, the ligature text (e.g., "delete") of a Material Symbol `<span>` is sometimes still announced by certain screen readers, causing repetitive or confusing announcements.
 **Action:** Always add `aria-hidden="true"` to Material Symbol `<span>` elements acting as ligatures to strictly enforce their decorative status and let the parent interactive element handle the accessible name.
+## 2026-03-26 - SVG Icon-Only Button Accessibility
+**Learning:** Icon-only buttons using SVG elements must have an `aria-label` on the `<button>` element describing the action, and the inner `<svg>` element must have `aria-hidden="true"` to prevent screen readers from announcing it incorrectly or redundantly. Dynamic lists should include item-specific context in the label.
+**Action:** Always verify that icon-only buttons include descriptive `aria-label`s (dynamic if inside lists) and hide decorative SVGs using `aria-hidden="true"`.

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -90,8 +90,8 @@ interface ActivityFeedProps {
 const ActivityFeed: React.FC<ActivityFeedProps> = React.memo(({ activities, loading }) => {
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <span className="material-symbols-outlined animate-spin text-primary-600 text-4xl">
+      <div className="flex items-center justify-center py-8" role="status" aria-label="Loading activity feed">
+        <span className="material-symbols-outlined animate-spin text-primary-600 text-4xl" aria-hidden="true">
           progress_activity
         </span>
       </div>
@@ -124,7 +124,7 @@ const ActivityFeed: React.FC<ActivityFeedProps> = React.memo(({ activities, load
             <div key={activity.id} className={`relative flex gap-4 ${isLast ? '' : 'mb-4'}`}>
               {/* Timeline dot */}
               <div className="w-10 h-10 rounded-full bg-white border-2 border-slate-200 flex items-center justify-center flex-shrink-0 z-10">
-                <span className={`material-symbols-outlined text-[20px] ${color}`}>{icon}</span>
+                <span className={`material-symbols-outlined text-[20px] ${color}`} aria-hidden="true">{icon}</span>
               </div>
 
               {/* Activity content */}

--- a/components/activity/ActivityFeed.tsx
+++ b/components/activity/ActivityFeed.tsx
@@ -43,8 +43,9 @@ export const NotificationsBell: React.FC<NotificationsBellProps> = ({ onOpenPane
       onClick={handleClick}
       className="relative p-2 text-gray-400 hover:text-gray-600 transition"
       title="Notifications"
+      aria-label="Notifications"
     >
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
       </svg>
       {unreadCount > 0 && (
@@ -186,8 +187,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600"
+              aria-label="Close notifications"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -240,8 +242,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                         onClick={() => handleMarkRead(notification.id)}
                         className="text-gray-400 hover:text-blue-600 p-1"
                         title="Mark as read"
+                        aria-label={`Mark "${notification.title}" as read`}
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
                       </button>
@@ -250,8 +253,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                       onClick={() => handleDelete(notification.id)}
                       className="text-gray-400 hover:text-red-600 p-1"
                       title="Delete"
+                      aria-label={`Delete notification "${notification.title}"`}
                     >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                       </svg>
                     </button>

--- a/components/activity/ActivityFeed.tsx
+++ b/components/activity/ActivityFeed.tsx
@@ -43,9 +43,8 @@ export const NotificationsBell: React.FC<NotificationsBellProps> = ({ onOpenPane
       onClick={handleClick}
       className="relative p-2 text-gray-400 hover:text-gray-600 transition"
       title="Notifications"
-      aria-label="Notifications"
     >
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
       </svg>
       {unreadCount > 0 && (
@@ -187,9 +186,8 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600"
-              aria-label="Close notifications"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -242,9 +240,8 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                         onClick={() => handleMarkRead(notification.id)}
                         className="text-gray-400 hover:text-blue-600 p-1"
                         title="Mark as read"
-                        aria-label={`Mark "${notification.title}" as read`}
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
                       </button>
@@ -253,9 +250,8 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                       onClick={() => handleDelete(notification.id)}
                       className="text-gray-400 hover:text-red-600 p-1"
                       title="Delete"
-                      aria-label={`Delete notification "${notification.title}"`}
                     >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                       </svg>
                     </button>


### PR DESCRIPTION
Adds missing accessibility tags (aria-label and aria-hidden) to icon-only buttons within the components/activity/ActivityFeed.tsx file, including dynamically context-aware labels for list items.

---
*PR created automatically by Jules for task [2573323304842201992](https://jules.google.com/task/2573323304842201992) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only notification controls and document SVG button ARIA guidelines in Palette.

New Features:
- Provide descriptive ARIA labels for icon-only notification buttons, including context-aware labels for list items.

Enhancements:
- Hide decorative SVG icons in notification controls from screen readers using aria-hidden attributes.
- Document accessibility guidelines for SVG-based icon-only buttons in the Palette notes.