### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Argument Injection in ecryptfs_utils

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2024-05-19 - [Command Injection/Argument Injection via subprocess.run without -- and missing timeout]
+**Vulnerability:** The `is_ecryptfs_path` function in `resume-api/lib/utils/ecryptfs_utils.py` used `subprocess.run` to execute `df` with unsanitized user input (`path`), leading to potential argument injection. Without `--`, an attacker could pass a path starting with `-` to inject arguments. Furthermore, the missing `timeout` parameter exposed the application to Denial of Service via resource exhaustion.
+**Learning:** Even when avoiding `shell=True`, passing unvalidated user inputs to command line arguments is dangerous. Furthermore, synchronous external command execution must always specify a `timeout` to avoid blocking the application.
+**Prevention:** Always include `--` to separate command line options from arguments. Always include a strict `timeout` parameter and handle `subprocess.TimeoutExpired` when executing external commands via `subprocess.run`.

--- a/resume-api/lib/utils/ecryptfs_utils.py
+++ b/resume-api/lib/utils/ecryptfs_utils.py
@@ -28,12 +28,15 @@ def is_ecryptfs_path(path: str) -> bool:
     try:
         # Get the filesystem type for the path securely without shell execution
         result = subprocess.run(
-            ["df", "-Th", path],
+            ["df", "-Th", "--", path],
             capture_output=True,
             text=True,
             check=False,
+            timeout=15,
         ).stdout
         return "ecryptfs" in result.lower()
+    except subprocess.TimeoutExpired:
+        return False
     except Exception:
         return False
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `is_ecryptfs_path` function in `resume-api/lib/utils/ecryptfs_utils.py` used `subprocess.run` to execute `df` with unsanitized user input (`path`), leading to potential argument injection because it didn't separate arguments with `--`. In addition, it was lacking a `timeout` argument which poses a DoS risk if the subprocess hangs.
🎯 Impact: Attackers could inject arbitrary arguments to the command, or hang the server.
🔧 Fix: Added `--` to the `subprocess.run` call to separate command options from arguments, and added a `timeout=15` argument while catching `subprocess.TimeoutExpired` to prevent resource exhaustion. 
✅ Verification: Tested syntax by running `python -m py_compile resume-api/lib/utils/ecryptfs_utils.py`. Recorded the vulnerability in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2919502590480456584](https://jules.google.com/task/2919502590480456584) started by @anchapin*

## Summary by Sourcery

Harden subprocess usage in ecryptfs path detection to prevent command/argument injection and hanging processes, and document the vulnerability in the Sentinel security log.

Bug Fixes:
- Prevent argument injection in ecryptfs path detection by passing the target path as a non-option argument separated with `--` when invoking `df`.
- Mitigate potential denial-of-service from hanging `df` subprocesses by enforcing a timeout and treating timeouts as non-ecryptfs paths.

Documentation:
- Record the subprocess argument injection and timeout vulnerability, its impact, and remediation steps in `.jules/sentinel.md` for future security reference.