### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix argument injection in ecryptfs_utils

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-05-18 - [Argument Injection via subprocess.run]
+**Vulnerability:** The `is_ecryptfs_path` function in `resume-api/lib/utils/ecryptfs_utils.py` passed user-provided variables directly as arguments to `subprocess.run(["df", "-Th", path])`. If the path started with a hyphen (e.g., `-P`), it would be interpreted as a command flag, leading to an argument injection vulnerability.
+**Learning:** Even when avoiding `shell=True` and using argument lists, variables passed to system commands can cause injection vulnerabilities if they are interpreted as options by the external executable.
+**Prevention:** Always prepend a variable that is meant to be a positional argument with `--` (end-of-options indicator) when passing it to commands that support it (like most POSIX commands), e.g., `["df", "-Th", "--", path]`.

--- a/resume-api/lib/utils/ecryptfs_utils.py
+++ b/resume-api/lib/utils/ecryptfs_utils.py
@@ -28,7 +28,7 @@ def is_ecryptfs_path(path: str) -> bool:
     try:
         # Get the filesystem type for the path securely without shell execution
         result = subprocess.run(
-            ["df", "-Th", path],
+            ["df", "-Th", "--", path],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `is_ecryptfs_path` function passed user-provided paths directly to `subprocess.run(["df", "-Th", path])`. If a path started with a hyphen (e.g., `-P`), `df` would interpret it as an option flag rather than a path, allowing argument injection.
🎯 **Impact**: Argument injection can lead to unexpected command execution behaviors or failures, and potentially unhandled errors or unintended information disclosure depending on the command and the environment.
🔧 **Fix**: Appended `--` (the POSIX end-of-options indicator) before the path variable in the `subprocess.run` argument list: `["df", "-Th", "--", path]`.
✅ **Verification**: Verified using a local test script that `-h` and `--help` are safely handled as path arguments without invoking the `df` command's help output, and linted the file using `ruff`. Added an entry to `.jules/sentinel.md` to document the finding.

---
*PR created automatically by Jules for task [3974129045228072381](https://jules.google.com/task/3974129045228072381) started by @anchapin*

## Summary by Sourcery

Mitigate an argument injection vulnerability in ecryptfs path detection and document the security finding in Sentinel notes.

Bug Fixes:
- Ensure ecryptfs path detection calls `df` with `--` before user-provided paths to prevent option-based argument injection.

Documentation:
- Add a Sentinel security entry describing the subprocess argument injection issue, its impact, and recommended prevention practices.