### PR TITLE
🎨 Palette: Hide Material Symbol ligatures from screen readers in ResumeCard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2024-05-23 - Material Symbol Ligature Screen Reader Noise in Complex Interactive Cards
+**Learning:** In complex interactive components like `ResumeCard`, multiple `material-symbols-outlined` span elements acting as ligatures (e.g., "update", "share", "edit", "content_copy", "check", "close", "delete", "history") can create significant noise for screen reader users, even when the parent interactive elements have proper `aria-label`s.
+**Action:** Always add `aria-hidden="true"` to all Material Symbol span elements acting as ligatures, regardless of whether they are standalone or inside `Button` components with `aria-label`s, to strictly enforce their decorative status and prevent redundant screen reader announcements.

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">update</span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +88,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">share</span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +97,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">edit</span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +106,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">content_copy</span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +124,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span className="material-symbols-outlined text-[18px] font-bold" aria-hidden="true">check</span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +138,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">close</span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +154,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">delete</span>
               </Button>
             )}
           </div>
@@ -182,7 +182,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">history</span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to all instances of `material-symbols-outlined` spans within `components/ResumeCard.tsx`.

🎯 **Why**: When using ligature-based icon fonts, screen readers often read the text content of the span (e.g., "share", "delete") in addition to the parent button's `aria-label`. This creates a noisy and confusing experience for users relying on assistive technologies (e.g., hearing "Share Resume share button").

♿ **Accessibility**: 
- Silenced decorative and redundant icon text for screen reader users.
- Ensured interactive elements rely solely on their descriptive `aria-label`s.

---
*PR created automatically by Jules for task [16789650238379832084](https://jules.google.com/task/16789650238379832084) started by @anchapin*

## Summary by Sourcery

Improve accessibility of ResumeCard iconography by marking decorative Material Symbol ligatures as hidden from assistive technologies.

Bug Fixes:
- Prevent screen readers from redundantly announcing Material Symbol ligature text for ResumeCard actions that already have descriptive aria-labels.

Documentation:
- Document the accessibility decision to hide Material Symbol ligature icons from screen readers in the Palette guidance.