### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix argument injection in is_ecryptfs_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,9 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-05-10 - [Argument Injection via Path in subprocess.run]
+
+**Vulnerability:** The `is_ecryptfs_path` function in `resume-api/lib/utils/ecryptfs_utils.py` used `subprocess.run(["df", "-Th", path])` to get the filesystem type for a user-provided path. If the `path` started with a hyphen (e.g., `-t`), the `df` command would interpret it as an option instead of a positional argument, leading to an argument injection vulnerability.
+**Learning:** Even when using `subprocess.run` with a list of arguments (which prevents command injection by avoiding shell execution), the executed command might still misinterpret user input starting with `-` or `--` as command-line options.
+**Prevention:** Always use the end-of-options marker (`--`) before passing variable arguments to command-line tools that accept options (e.g., `["df", "-Th", "--", path]`).

--- a/resume-api/lib/utils/ecryptfs_utils.py
+++ b/resume-api/lib/utils/ecryptfs_utils.py
@@ -28,7 +28,7 @@ def is_ecryptfs_path(path: str) -> bool:
     try:
         # Get the filesystem type for the path securely without shell execution
         result = subprocess.run(
-            ["df", "-Th", path],
+            ["df", "-Th", "--", path],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Argument injection in `subprocess.run(["df", "-Th", path])` could allow a user-provided path starting with `-` to be interpreted as a command-line option by `df`.
🎯 Impact: Could lead to unexpected command execution or information disclosure.
🔧 Fix: Added `--` to the argument list to mark the end of options, forcing `df` to treat the user-provided string strictly as a path.
✅ Verification: Ran `ruff check` and `python -m py_compile` to ensure syntax validity.

---
*PR created automatically by Jules for task [7163684122324223071](https://jules.google.com/task/7163684122324223071) started by @anchapin*

## Summary by Sourcery

Fix argument injection in the ecryptfs filesystem detection helper and document the vulnerability in the Sentinel security log.

Bug Fixes:
- Harden ecryptfs path detection by ensuring user-provided paths to df are passed after an explicit end-of-options marker to prevent argument injection.

Documentation:
- Add Sentinel entry describing the df argument injection vulnerability, its impact, and recommended prevention pattern when using subprocess with user-supplied paths.