### PR TITLE
🎨 Palette: Add aria-pressed to tab buttons for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-04-10 - Accessibility for Custom Toggle and Tab Buttons
+**Learning:** Found custom tab button implementations that used color styling to denote active states but lacked programmatic indications. This makes the interface inaccessible to screen reader users who cannot visually perceive the active state.
+**Action:** When implementing custom tab components or toggle buttons that use visual active classes, always include the `aria-pressed` attribute (e.g. `aria-pressed={activeTab === 'overview'}`) to correctly announce the active state to screen readers.

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -39,6 +39,7 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
       <div className="flex gap-2 border-b border-slate-200">
         <button
           onClick={() => setActiveTab('overview')}
+          aria-pressed={activeTab === 'overview'}
           className={`px-4 py-2 font-medium text-sm transition-colors ${
             activeTab === 'overview'
               ? 'text-primary-600 border-b-2 border-primary-600'
@@ -49,6 +50,7 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('details')}
+          aria-pressed={activeTab === 'details'}
           className={`px-4 py-2 font-medium text-sm transition-colors ${
             activeTab === 'details'
               ? 'text-primary-600 border-b-2 border-primary-600'
@@ -59,6 +61,7 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('analysis')}
+          aria-pressed={activeTab === 'analysis'}
           className={`px-4 py-2 font-medium text-sm transition-colors ${
             activeTab === 'analysis'
               ? 'text-primary-600 border-b-2 border-primary-600'

--- a/components/editor/EditorTabs.tsx
+++ b/components/editor/EditorTabs.tsx
@@ -17,6 +17,7 @@ export const EditorTabs = React.memo<EditorTabsProps>(({ activeTab, onTabChange 
             <button
               key={tab}
               onClick={() => onTabChange(tab)}
+              aria-pressed={active}
               className={`pb-3 pt-2 text-sm font-bold border-b-[3px] transition-colors ${
                 active
                   ? 'border-primary-600 text-slate-900'


### PR DESCRIPTION
**💡 What:** 
Added `aria-pressed` attributes to custom tab and toggle buttons in `components/OfferComparison.tsx` and `components/editor/EditorTabs.tsx`.

**🎯 Why:**
The tab buttons previously used visual cues (borders and colors) to indicate which tab was active, but lacked programmatic state indicators for screen reader users, making the active state inaccessible.

**♿ Accessibility:**
The active state of these buttons is now correctly announced to screen reader users (e.g. "Overview, toggle button, pressed").

---
*PR created automatically by Jules for task [3450180645932863209](https://jules.google.com/task/3450180645932863209) started by @anchapin*

## Summary by Sourcery

Improve accessibility of custom tab and toggle buttons by exposing their active state to assistive technologies.

New Features:
- Announce active state of offer comparison tabs via aria-pressed on each tab button.
- Expose active state of editor tabs as pressed for screen readers using aria-pressed on the tab buttons.

Documentation:
- Add Palette accessibility guideline documenting use of aria-pressed on custom tab and toggle buttons.