### PR TITLE
⚡ Bolt: Resolve N+1 query performance issue in list_teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 # Dependency reports
 .unused-deps-report.json
 .deps-audit.json
+venv/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+
+## 2024-05-28 - Optimize N+1 Query in Teams Listing
+**Learning:** Iterating over a list of records and making separate `COUNT` queries for each record (e.g., `member_count` and `resume_count` for each team in `list_teams`) leads to an N+1 query bottleneck.
+**Action:** Always pre-fetch aggregates for collections by using a single query with a `GROUP BY` clause and an `IN` condition on the collection of IDs. Map the results into a dictionary for O(1) retrieval during the loop to dramatically reduce database round-trips.

--- a/resume-api/.gitignore
+++ b/resume-api/.gitignore
@@ -50,3 +50,4 @@ htmlcov/
 # OS
 .DS_Store
 Thumbs.db
+venv

--- a/resume-api/api/team_routes.py
+++ b/resume-api/api/team_routes.py
@@ -183,19 +183,26 @@ async def list_teams(
         result = await db.execute(stmt)
         teams = result.scalars().all()
 
+        team_ids = [team.id for team in teams]
+
+        member_counts = {}
+        resume_counts = {}
+
+        if team_ids:
+            member_count_stmt = select(TeamMember.team_id, func.count(TeamMember.id)).where(TeamMember.team_id.in_(team_ids)).group_by(TeamMember.team_id)
+            member_count_result = await db.execute(member_count_stmt)
+            for team_id, count in member_count_result.all():
+                member_counts[team_id] = count
+
+            resume_count_stmt = select(TeamResume.team_id, func.count(TeamResume.id)).where(TeamResume.team_id.in_(team_ids)).group_by(TeamResume.team_id)
+            resume_count_result = await db.execute(resume_count_stmt)
+            for team_id, count in resume_count_result.all():
+                resume_counts[team_id] = count
+
         team_responses = []
         for team in teams:
-            member_count_stmt = select(func.count(TeamMember.id)).where(
-                TeamMember.team_id == team.id
-            )
-            result = await db.execute(member_count_stmt)
-            member_count = result.scalar() or 0
-
-            resume_count_stmt = select(func.count(TeamResume.id)).where(
-                TeamResume.team_id == team.id
-            )
-            result = await db.execute(resume_count_stmt)
-            resume_count = result.scalar() or 0
+            member_count = member_counts.get(team.id, 0)
+            resume_count = resume_counts.get(team.id, 0)
 
             team_responses.append(
                 TeamResponse(


### PR DESCRIPTION
💡 What: Replaced iterative sequential COUNT queries for `member_count` and `resume_count` in the `list_teams` endpoint with two batched queries using `in_` and `group_by`.
🎯 Why: Iterating over teams and making two separate count queries per team is an N+1 query problem, creating a massive bottleneck on the database when users have many teams.
📊 Impact: Reduces the number of database queries from O(2N + 1) down to O(1) (exactly 3 queries) when fetching teams, significantly decreasing latency and database load.
🔬 Measurement: Verified by reviewing query logs and confirming `pytest tests/test_teams.py` still passes.

---
*PR created automatically by Jules for task [1340199015330670166](https://jules.google.com/task/1340199015330670166) started by @anchapin*

## Summary by Sourcery

Optimize the teams listing endpoint to eliminate N+1 aggregate queries for member and resume counts by batching counts per team.

Enhancements:
- Batch member and resume count queries for teams using grouped lookups instead of per-team COUNT queries to improve performance.
- Record the N+1 query optimization and its rationale in the Bolt engineering learnings document.