### PR TITLE
🎨 Palette: Improve OfferComparison tab navigation and icon accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2026-04-12 - Material Symbols ARIA Hidden Validation
+**Learning:** Decorative Material Symbol icons, such as check/close marks inside pros and cons lists or star icons in recommendation banners, continue to require `aria-hidden="true"` to prevent redundant screen reader announcements, especially when their parent elements have adequate semantic text content.
+**Action:** Consistently apply `aria-hidden="true"` to all Material Symbols acting as ligatures for decorative purposes alongside visible text.

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -39,7 +39,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
       <div className="flex gap-2 border-b border-slate-200">
         <button
           onClick={() => setActiveTab('overview')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'overview' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-md ${
             activeTab === 'overview'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -49,7 +50,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('details')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'details' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-md ${
             activeTab === 'details'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -59,7 +61,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('analysis')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'analysis' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-md ${
             activeTab === 'analysis'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -76,7 +79,9 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
           <div className="bg-gradient-to-r from-primary-500 to-primary-600 rounded-xl p-6 text-white">
             <div className="flex items-start gap-4">
               <div className="bg-white/20 size-12 rounded-full flex items-center justify-center flex-shrink-0">
-                <span className="material-symbols-outlined text-2xl">star</span>
+                <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+                  star
+                </span>
               </div>
               <div className="flex-1">
                 <h3 className="font-bold text-lg mb-1">Recommended Offer</h3>
@@ -344,13 +349,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.pros.length > 0 && (
                     <div className="bg-green-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-green-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_up</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_up
+                        </span>
                         Pros
                       </h5>
                       <ul className="space-y-1">
                         {score.pros.map((pro, idx) => (
                           <li key={idx} className="text-sm text-green-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               check
                             </span>
                             {pro}
@@ -363,13 +373,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.cons.length > 0 && (
                     <div className="bg-red-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-red-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_down</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_down
+                        </span>
                         Cons
                       </h5>
                       <ul className="space-y-1">
                         {score.cons.map((con, idx) => (
                           <li key={idx} className="text-sm text-red-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               close
                             </span>
                             {con}


### PR DESCRIPTION
💡 **What:** Added `aria-current="page"` and `focus-visible` styles to the custom tab navigation. Added `aria-hidden="true"` to decorative Material Symbol ligature icons (`star`, `thumb_up`, `check`, etc.).
🎯 **Why:** To prevent screen readers from redundantly announcing decorative ligature text alongside the visible content, and to ensure keyboard users can clearly see which tab is focused.
♿ **Accessibility:**
- Custom tabs now announce their active state properly and have a clear focus ring.
- Decorative Material Symbol `<span>`s are hidden from screen reader trees.

---
*PR created automatically by Jules for task [5249252740744031811](https://jules.google.com/task/5249252740744031811) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the OfferComparison tab navigation and decorative Material Symbol icons.

Enhancements:
- Mark active OfferComparison tabs with aria-current and add visible focus styles for keyboard navigation.
- Hide decorative Material Symbol ligature icons from assistive technologies using aria-hidden in pros/cons lists and recommendation banners.
- Document accessibility learnings and guidelines for custom tabs and Material Symbols in the Palette notes.