### PR TITLE
🎨 Palette: Improve EditorHeader Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+
+## 2026-04-13 - Label in Name WCAG compliance
+**Learning:** Adding an `aria-label` that doesn't contain the visible text of an element violates WCAG 2.5.3 (Label in Name), as it breaks voice recognition commands.
+**Action:** Always ensure that if an element has visible text, any `aria-label` added to it includes that visible text as part of its string.

--- a/components/editor/EditorHeader.tsx
+++ b/components/editor/EditorHeader.tsx
@@ -9,12 +9,18 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({ onNavigate }) => {
 
   return (
     <header className="flex items-center justify-between px-10 py-3 bg-white border-b border-slate-200 sticky top-0 z-30 shadow-sm">
-      <div className="flex items-center gap-4 cursor-pointer" onClick={onNavigate}>
+      <button
+        className="flex items-center gap-4 cursor-pointer focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:outline-none rounded-lg p-1 -ml-1"
+        onClick={onNavigate}
+        aria-label="ResumeBuilder SaaS - Go to Dashboard"
+      >
         <div className="bg-primary-600 size-8 rounded-lg flex items-center justify-center text-white">
-          <span className="material-symbols-outlined text-[18px]">description</span>
+          <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+            description
+          </span>
         </div>
         <h2 className="text-slate-900 text-lg font-bold">ResumeBuilder SaaS</h2>
-      </div>
+      </button>
       <div className="flex items-center gap-8">
         <nav className="flex gap-6">
           {NAV_ITEMS.map((item) => (


### PR DESCRIPTION
🎨 Palette: Improve EditorHeader Accessibility

💡 What: Converted the Home/Dashboard link div in `EditorHeader` to a semantic `<button>` with focus states.
🎯 Why: The original implementation used a generic `div` with `onClick`, breaking keyboard accessibility and screen reader support.
♿ Accessibility:
- Changed `div` to `button` for native keyboard interaction.
- Added `focus-visible` styles to clearly indicate keyboard focus.
- Added `aria-label` including the visible text to satisfy WCAG 2.5.3.
- Added `aria-hidden="true"` to the decorative icon ligature to prevent repetitive screen reader announcements.

---
*PR created automatically by Jules for task [8969429494283103440](https://jules.google.com/task/8969429494283103440) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the editor header dashboard control and document related accessibility guidance.

Enhancements:
- Make the editor header dashboard control a semantic button with proper focus-visible styling and ARIA attributes for better keyboard and screen reader accessibility.

Documentation:
- Add accessibility guidance on WCAG 2.5.3 Label in Name compliance to the Palette documentation.