### PR TITLE
🎨 Palette: Improve accessibility in Share Dialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+
+## 2024-05-18 - Dynamically updating aria-labels on buttons with changing text
+**Learning:** When interactive elements (like a "Copy" button) visually change their text (e.g., to "Copied!") upon interaction, the `aria-label` and `title` attributes must also dynamically update to match the new visible text. This ensures compliance with WCAG 2.5.3 (Label in Name) and provides immediate, accessible feedback to screen reader users about the state change.
+**Action:** Always bind the `aria-label` and `title` of buttons to the exact same dynamic state variables used for their visible text content when the button provides immediate interaction feedback.

--- a/components/ShareDialog.tsx
+++ b/components/ShareDialog.tsx
@@ -105,6 +105,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
                 <button
                   key={perm}
                   onClick={() => setPermissions(perm as 'view' | 'comment' | 'edit')}
+                  aria-pressed={permissions === perm}
                   className={`px-4 py-3 rounded-lg border-2 font-bold text-sm capitalize transition-all ${
                     permissions === perm
                       ? 'border-primary-600 bg-primary-50 text-primary-700'
@@ -165,7 +166,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
                 aria-label={showPassword ? 'Hide password' : 'Show password'}
               >
-                <span className="material-symbols-outlined text-[20px]">
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                   {showPassword ? 'visibility_off' : 'visibility'}
                 </span>
               </button>
@@ -175,18 +176,24 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
           <button
             onClick={handleCreateShare}
             disabled={loading}
+            aria-busy={loading}
             className="w-full py-3 bg-primary-600 text-white font-bold rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             {loading ? (
               <>
-                <span className="material-symbols-outlined animate-spin text-[18px]">
+                <span
+                  className="material-symbols-outlined animate-spin text-[18px]"
+                  aria-hidden="true"
+                >
                   progress_activity
                 </span>
                 <span>Creating link...</span>
               </>
             ) : (
               <>
-                <span className="material-symbols-outlined text-[18px]">share</span>
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  share
+                </span>
                 <span>Create Share Link</span>
               </>
             )}
@@ -196,7 +203,9 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
         <div className="space-y-4">
           <div className="p-4 bg-green-50 border border-green-200 rounded-lg" role="alert">
             <div className="flex items-center gap-2 text-green-800">
-              <span className="material-symbols-outlined text-[24px]">check_circle</span>
+              <span className="material-symbols-outlined text-[24px]" aria-hidden="true">
+                check_circle
+              </span>
               <span className="font-bold">Share link created!</span>
             </div>
           </div>
@@ -212,10 +221,11 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
               />
               <button
                 onClick={handleCopyLink}
-                aria-label="Copy share link"
+                aria-label={copied ? 'Copied!' : 'Copy share link'}
+                title={copied ? 'Copied!' : 'Copy share link'}
                 className="px-4 py-2.5 bg-primary-600 text-white font-bold rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
               >
-                <span className="material-symbols-outlined text-[20px]">
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                   {copied ? 'check' : 'content_copy'}
                 </span>
                 {copied ? 'Copied!' : 'Copy'}
@@ -225,7 +235,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
 
           <div className="space-y-2 text-sm text-slate-600">
             <div className="flex items-center gap-2">
-              <span className="material-symbols-outlined text-[20px] text-slate-400">
+              <span
+                className="material-symbols-outlined text-[20px] text-slate-400"
+                aria-hidden="true"
+              >
                 verified_user
               </span>
               <span>
@@ -235,7 +248,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
             </div>
             {shareLink.expiresAt && (
               <div className="flex items-center gap-2">
-                <span className="material-symbols-outlined text-[20px] text-slate-400">
+                <span
+                  className="material-symbols-outlined text-[20px] text-slate-400"
+                  aria-hidden="true"
+                >
                   schedule
                 </span>
                 <span>
@@ -248,7 +264,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
             )}
             {shareLink.maxViews && (
               <div className="flex items-center gap-2">
-                <span className="material-symbols-outlined text-[20px] text-slate-400">
+                <span
+                  className="material-symbols-outlined text-[20px] text-slate-400"
+                  aria-hidden="true"
+                >
                   visibility
                 </span>
                 <span>


### PR DESCRIPTION
**What:** Added missing ARIA attributes to `ShareDialog.tsx`.
**Why:** Screen readers lacked context for loading states, active toggle buttons, and dynamically changing text on the copy button. Additionally, the material symbols ligature texts were being read aloud unnecessarily.
**Accessibility:** Improved screen reader interaction, reduced noise, and fixed WCAG 2.5.3 (Label in Name) on the Copy button.

---
*PR created automatically by Jules for task [4153797625459500781](https://jules.google.com/task/4153797625459500781) started by @anchapin*

## Summary by Sourcery

Improve accessibility and screen reader behavior in the Share dialog’s controls and status messaging.

New Features:
- Add dynamic ARIA labels and titles to the Copy link button to reflect its copied state for assistive technologies.

Enhancements:
- Mark material icon glyphs as decorative via aria-hidden to prevent them from being read by screen readers.
- Expose the active state of permission toggle buttons with aria-pressed and indicate loading state on the share creation button with aria-busy.
- Document accessibility learnings and best practices for dynamic button labels in the Palette guide.