### PR TITLE
🎨 Palette: Add aria-hidden="true" to Material Symbols in ResumeCard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2024-05-24 - Missing aria-hidden in ResumeCard
+**Learning:** The `ResumeCard` component contained numerous interactive buttons with Material Symbol ligatures but without `aria-hidden="true"`. Even with `aria-label` present on parent buttons, some screen readers will announce the visible ligature text redundantly.
+**Action:** Always verify that every Material Symbol ligature (`<span className="material-symbols-outlined">`) includes `aria-hidden="true"` to ensure a clean, noise-free experience for screen reader users, relying strictly on parent `aria-label`s or accompanying visible text for context.

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    className="material-symbols-outlined text-[18px] font-bold"
+                    aria-hidden="true"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
## Description
Adds `aria-hidden="true"` to Material Symbols in `ResumeCard`.

### What
Added `aria-hidden="true"` to 8 `<span>` tags acting as decorative Material Symbol ligatures in `components/ResumeCard.tsx`.
Updated the Palette journal `.jules/palette.md` to document this critical learning.

### Why
Screen readers will read out the literal text inside a `<span>` element if it doesn't have `aria-hidden="true"`. For example, a button containing `<span className="material-symbols-outlined">share</span>` with an `aria-label="Share Resume"` would be announced as "Share Resume, share". This creates redundant and confusing noise for visually impaired users. By hiding the ligature, we ensure only the parent `aria-label` is announced.

### Accessibility
Massively improves screen reader experience on the Resume Cards by removing redundant ligature text announcements, letting the parent buttons' `aria-label` attribute act cleanly as the accessible name.

---
*PR created automatically by Jules for task [11266093582131378479](https://jules.google.com/task/11266093582131378479) started by @anchapin*

## Summary by Sourcery

Improve accessibility of ResumeCard Material Symbol icons and document the change in the Palette journal.

Enhancements:
- Mark decorative Material Symbol spans in ResumeCard as aria-hidden to prevent redundant screen reader announcements.
- Document accessibility learning about aria-hidden usage for Material Symbol ligatures in the Palette journal.