### PR TITLE
🎨 Palette: Add aria-label to notifications button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+
+## 2024-05-25 - Notifications aria label
+**Learning:** Notifications button often lack `aria-label` attribute but have decorative span elements for `material-symbols-outlined`. The decorative span elements should have `aria-hidden="true"` and the parent element should have `aria-label`.
+**Action:** Always add `aria-label="Notifications"` to the parent button and `aria-hidden="true"` to the decorative span element.

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -125,9 +125,9 @@ const Dashboard: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <div className="flex items-center gap-6">
           <h2 className="text-slate-800 font-bold text-xl">Job Search Overview</h2>
-          <Button 
-            variant="outline" 
-            size="sm" 
+          <Button
+            variant="outline"
+            size="sm"
             className="flex items-center gap-2"
             onClick={() => setShowImportDialog(true)}
           >
@@ -136,8 +136,10 @@ const Dashboard: React.FC = () => {
           </Button>
         </div>
         <div className="flex items-center gap-4">
-          <Button variant="ghost" className="p-2 relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <Button variant="ghost" className="p-2 relative" aria-label="Notifications">
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </Button>
           <div

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTheme } from '../hooks/useTheme';
 import { toast } from 'react-toastify';
@@ -346,8 +345,13 @@ const Settings: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <h2 className="text-slate-800 font-bold text-xl">Settings</h2>
         <div className="flex items-center gap-4">
-          <button className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <button
+            className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative"
+            aria-label="Notifications"
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </button>
           <div


### PR DESCRIPTION
Added `aria-label="Notifications"` to the notification buttons in `Dashboard.tsx` and `Settings.tsx` and added `aria-hidden="true"` to the decorative `material-symbols-outlined` span inside them to improve screen reader accessibility.

---
*PR created automatically by Jules for task [7431668274893875704](https://jules.google.com/task/7431668274893875704) started by @anchapin*

## Summary by Sourcery

Improve accessibility of notification buttons and document the accessibility pattern in the palette guidelines.

Bug Fixes:
- Add accessible labelling to notification buttons in Dashboard and Settings via aria-label on the button and aria-hidden on decorative icon spans.

Documentation:
- Document the notifications button aria-label and aria-hidden pattern in the palette accessibility guidelines.