### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat for Improved Render Performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,6 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+## 2026-04-17 - Cached Intl.NumberFormat for Improved Render Performance
+**Learning:** Instantiating `Intl.NumberFormat` repeatedly inside render cycles or loops is an expensive operation that degrades React render performance.
+**Action:** Extract formatters to utility files and cache instances in a `Map` using currency and formatting options as keys, returning the cached instance to avoid redundant allocations.

--- a/components/OfferCard.tsx
+++ b/components/OfferCard.tsx
@@ -1,4 +1,3 @@
- 
 import React from 'react';
 import { JobOffer } from '../types';
 import { Card } from './ui';
@@ -13,6 +12,8 @@ interface OfferCardProps {
   disabled?: boolean;
 }
 
+import { formatCurrencyValue } from '../utils/formatters';
+
 const STATUS_COLORS: Record<JobOffer['status'], { bg: string; text: string; border: string }> = {
   pending: { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200' },
   negotiating: { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200' },
@@ -21,12 +22,7 @@ const STATUS_COLORS: Record<JobOffer['status'], { bg: string; text: string; bord
 };
 
 const formatCurrency = (amount: number, currency: string = 'USD') => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
+  return formatCurrencyValue(amount, currency, 0, 0);
 };
 
 /**

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { OfferComparison as OfferComparisonType } from '../types';
 import { showSuccessToast } from '../utils/toast';
+import { formatCurrencyValue } from '../utils/formatters';
 
 interface OfferComparisonProps {
   comparison: OfferComparisonType;
@@ -8,12 +9,7 @@ interface OfferComparisonProps {
 }
 
 const formatCurrency = (amount: number, currency: string = 'USD') => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
+  return formatCurrencyValue(amount, currency, 0, 0);
 };
 
 /**

--- a/pages/Billing.tsx
+++ b/pages/Billing.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
@@ -11,6 +10,7 @@ import {
   resumeSubscription,
   createPortalSession,
 } from '../utils/api-client';
+import { formatCurrencyValue } from '../utils/formatters';
 
 const Billing: React.FC = () => {
   const location = useLocation();
@@ -127,12 +127,7 @@ const Billing: React.FC = () => {
   };
 
   const formatPrice = (cents: number, currency: string) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(cents / 100);
+    return formatCurrencyValue(cents / 100, currency, 0, 0);
   };
 
   const getUsageProgress = (usage: BillingUsage, key: 'resume_generated' | 'ai_tailored') => {

--- a/pages/Invoices.tsx
+++ b/pages/Invoices.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Invoice, listInvoices } from '../utils/api-client';
+import { formatCurrencyValue } from '../utils/formatters';
 
 const Invoices: React.FC = () => {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
@@ -54,10 +55,7 @@ const Invoices: React.FC = () => {
   };
 
   const formatAmount = (cents: number, currency: string) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency,
-    }).format(cents / 100);
+    return formatCurrencyValue(cents / 100, currency);
   };
 
   const handleDownload = (invoice: Invoice) => {

--- a/pages/Plans.tsx
+++ b/pages/Plans.tsx
@@ -6,6 +6,7 @@ import {
   createCheckoutSession,
   CheckoutSessionRequest,
 } from '../utils/api-client';
+import { formatCurrencyValue } from '../utils/formatters';
 
 const Plans: React.FC = () => {
   const [plans, setPlans] = useState<BillingPlan[]>([]);
@@ -49,12 +50,7 @@ const Plans: React.FC = () => {
   };
 
   const formatPrice = (cents: number, currency: string) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(cents / 100);
+    return formatCurrencyValue(cents / 100, currency, 0, 0);
   };
 
   if (loading) {

--- a/pages/SalaryResearch.tsx
+++ b/pages/SalaryResearch.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect } from 'react';
 import { JobOfferFormData } from '../types';
 import { Button, Card } from '../components/ui';
@@ -22,14 +21,10 @@ import { OfferCard } from '../components/OfferCard';
 import { OfferComparison } from '../components/OfferComparison';
 import { PrioritySliders } from '../components/PrioritySliders';
 import { toast } from 'react-toastify';
+import { formatCurrencyValue } from '../utils/formatters';
 
 const formatCurrency = (amount: number, currency: string = 'USD') => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
+  return formatCurrencyValue(amount, currency, 0, 0);
 };
 
 /**

--- a/utils/formatters.ts
+++ b/utils/formatters.ts
@@ -1,0 +1,47 @@
+// utils/formatters.ts
+
+/**
+ * Cache for Intl.NumberFormat instances.
+ * Instantiating Intl.NumberFormat is expensive and doing it repeatedly in render cycles
+ * or loops causes measurable performance degradation.
+ */
+const currencyFormatterCache = new Map<string, Intl.NumberFormat>();
+
+/**
+ * Returns a cached currency formatter based on the provided options.
+ */
+export const getCurrencyFormatter = (
+  currency: string,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+) => {
+  const cacheKey = `${currency}-${minimumFractionDigits ?? 'none'}-${maximumFractionDigits ?? 'none'}`;
+
+  if (!currencyFormatterCache.has(cacheKey)) {
+    currencyFormatterCache.set(
+      cacheKey,
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: currency,
+        minimumFractionDigits,
+        maximumFractionDigits,
+      }),
+    );
+  }
+
+  return currencyFormatterCache.get(cacheKey)!;
+};
+
+/**
+ * Formats an amount as currency using a cached Intl.NumberFormat instance.
+ */
+export const formatCurrencyValue = (
+  amount: number,
+  currency: string = 'USD',
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+) => {
+  return getCurrencyFormatter(currency, minimumFractionDigits, maximumFractionDigits).format(
+    amount,
+  );
+};


### PR DESCRIPTION
💡 **What**: Added `utils/formatters.ts` to cache `Intl.NumberFormat` instances and replaced local instantiations across multiple components and pages (`OfferComparison`, `OfferCard`, `SalaryResearch`, `Invoices`, `Billing`, `Plans`).
🎯 **Why**: `Intl.NumberFormat` instantiation is relatively slow and doing it inside React render cycles (especially in lists like invoices or cards) causes measurable performance degradation and jank.
📊 **Impact**: Reduces main-thread blocking by preventing redundant object allocation and garbage collection for formatters during re-renders, significantly improving rendering performance on lists of currency values.
🔬 **Measurement**: Verified the change visually and via full test suite (`pnpm test run`) passing. Formatting is preserved perfectly since the cache key correctly incorporates currency and min/max fraction digits.

---
*PR created automatically by Jules for task [10919059855690507932](https://jules.google.com/task/10919059855690507932) started by @anchapin*

## Summary by Sourcery

Introduce a shared currency formatting utility backed by a cached Intl.NumberFormat and adopt it across pricing-related components and pages to improve render performance.

Enhancements:
- Add a utils/formatters module that caches Intl.NumberFormat instances for currency formatting.
- Refactor OfferCard, OfferComparison, SalaryResearch, Invoices, Billing, and Plans to use the shared cached currency formatter instead of instantiating Intl.NumberFormat inline.
- Document the performance learning and caching approach in the .jules/bolt.md knowledge file.