### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck in advanced route batch operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 # Dependency reports
 .unused-deps-report.json
 .deps-audit.json
+venv/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+
+## 2024-05-28 - Fix N+1 Query in Batch Operations
+**Learning:** In SQLAlchemy, iterating over `request.resume_ids` and fetching each `Resume` object by ID individually inside a loop for batch operations (`batch_delete`, `batch_update`, `batch_export`, `bulk_operations`) causes severe N+1 query bottlenecks, especially since each query also performs `selectinload` for tags/versions.
+**Action:** Always pre-fetch existing parent entities outside of the loop using `.where(Model.id.in_(list_of_ids))` and map the results to a dictionary for O(1) lookups during the batch processing.

--- a/resume-api/api/advanced_routes.py
+++ b/resume-api/api/advanced_routes.py
@@ -1022,10 +1022,16 @@ async def bulk_operations(
         successful = []
         failed = []
 
+        # Pre-fetch resumes to avoid N+1 queries
+        if request.resume_ids:
+            resumes_result = await db.execute(select(Resume).where(Resume.id.in_(request.resume_ids)))
+            resumes_dict = {r.id: r for r in resumes_result.scalars().all()}
+        else:
+            resumes_dict = {}
+
         for resume_id in request.resume_ids:
             try:
-                result = await db.execute(select(Resume).where(Resume.id == resume_id))
-                resume = result.scalar_one_or_none()
+                resume = resumes_dict.get(resume_id)
 
                 if not resume:
                     failed.append({"id": resume_id, "error": "Resume not found"})
@@ -1197,16 +1203,23 @@ async def batch_update_resumes(
     successful = []
     failed = []
 
+    # Pre-fetch all resumes by ID to avoid N+1
+    update_ids = [r.id for r in request.resumes if hasattr(r, "id") and r.id is not None]
+    if update_ids:
+        resumes_result = await db.execute(
+            select(Resume)
+            .options(selectinload(Resume.tags))
+            .options(selectinload(Resume.versions))
+            .where(Resume.id.in_(update_ids))
+        )
+        resumes_dict = {r.id: r for r in resumes_result.scalars().all()}
+    else:
+        resumes_dict = {}
+
     for idx, update_request in enumerate(request.resumes):
         try:
             # Get resume by ID
-            result = await db.execute(
-                select(Resume)
-                .options(selectinload(Resume.tags))
-                .options(selectinload(Resume.versions))
-                .where(Resume.id == update_request.id)
-            )
-            resume = result.scalar_one_or_none()
+            resume = resumes_dict.get(update_request.id)
 
             if not resume:
                 failed.append(
@@ -1304,12 +1317,18 @@ async def batch_delete_resumes(
     successful = []
     failed = []
 
+    # Pre-fetch all resumes by ID to avoid N+1
+    if request.resume_ids:
+        resumes_result = await db.execute(
+            select(Resume).options(selectinload(Resume.tags)).where(Resume.id.in_(request.resume_ids))
+        )
+        resumes_dict = {r.id: r for r in resumes_result.scalars().all()}
+    else:
+        resumes_dict = {}
+
     for resume_id in request.resume_ids:
         try:
-            result = await db.execute(
-                select(Resume).options(selectinload(Resume.tags)).where(Resume.id == resume_id)
-            )
-            resume = result.scalar_one_or_none()
+            resume = resumes_dict.get(resume_id)
 
             if not resume:
                 failed.append({"id": resume_id, "error": "Resume not found"})
@@ -1356,12 +1375,18 @@ async def batch_export_resumes(
     failed = []
     export_job_id = str(uuid.uuid4())
 
+    # Pre-fetch all resumes by ID to avoid N+1
+    if request.resume_ids:
+        resumes_result = await db.execute(
+            select(Resume).options(selectinload(Resume.tags)).where(Resume.id.in_(request.resume_ids))
+        )
+        resumes_dict = {r.id: r for r in resumes_result.scalars().all()}
+    else:
+        resumes_dict = {}
+
     for resume_id in request.resume_ids:
         try:
-            result = await db.execute(
-                select(Resume).options(selectinload(Resume.tags)).where(Resume.id == resume_id)
-            )
-            resume = result.scalar_one_or_none()
+            resume = resumes_dict.get(resume_id)
 
             if not resume:
                 failed.append({"id": resume_id, "error": "Resume not found"})


### PR DESCRIPTION
💡 What: Eliminated N+1 query patterns in all four batch/bulk operation endpoints inside `advanced_routes.py` by fetching required `Resume` entities outside of processing loops.
🎯 Why: Iterating over request arrays and performing `select(Resume).where(Resume.id == id)` individually inside loops caused significant database latency, especially as each query included `selectinload` for tags and versions.
📊 Impact: Reduces database queries for these endpoints from O(N) to O(1) during the entity fetch phase.
🔬 Measurement: Verify by executing batch update or delete requests with 10-50 resume IDs; profiling tools or SQL logging will show a single `IN` query instead of N individual queries.

---
*PR created automatically by Jules for task [4262973319830091513](https://jules.google.com/task/4262973319830091513) started by @anchapin*

## Summary by Sourcery

Optimize advanced resume batch operations to remove N+1 query patterns by prefetching resumes in a single query and reusing them across processing loops.

Enhancements:
- Prefetch resumes for bulk operations, batch update, batch delete, and batch export endpoints using a single IN query and reuse them from an in-memory map.
- Document the N+1 query issue and the preferred prefetch pattern for SQLAlchemy batch operations in the Bolt engineering notes.