### PR TITLE
🎨 Palette: Prevent redundant screen reader announcements for Material Symbols in ResumeCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,6 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+## 2025-05-24 - Ensure aria-hidden for ligature icons
+**Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
+**Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[16px]">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    aria-hidden="true"
+                    className="material-symbols-outlined text-[18px] font-bold"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span aria-hidden="true" className="material-symbols-outlined text-[18px]">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span aria-hidden="true" className="material-symbols-outlined text-[16px]">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
💡 **What**: Added `aria-hidden="true"` to `<span className="material-symbols-outlined">` elements in the `ResumeCard` component.
🎯 **Why**: When Material Symbols are used inside buttons that already have an `aria-label`, screen readers will often read both the aria-label and the text content of the span (which is the icon's ligature name, like "share" or "delete"). This leads to redundant and confusing announcements for users relying on assistive technologies.
📸 **Before/After**: No visual change.
♿ **Accessibility**: Prevents screen readers from reading decorative ligature text, significantly cleaning up the auditory interface of the resume cards.

---
*PR created automatically by Jules for task [13435196209512124341](https://jules.google.com/task/13435196209512124341) started by @anchapin*

## Summary by Sourcery

Improve accessibility of ResumeCard icon buttons by hiding decorative Material Symbols from screen readers and documenting the pattern in the Palette guide.

Bug Fixes:
- Prevent screen readers from redundantly announcing Material Symbol ligature text for icon-only controls in ResumeCard by marking the icon spans as aria-hidden.

Documentation:
- Document the aria-hidden pattern for ligature-based Material Symbols in the Palette guidance to avoid redundant screen reader announcements in future components.