### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-03-09 - Added missing aria-hidden and aria-labels on icon-only buttons
+**Learning:** Found multiple instances where icon-only buttons (`Settings.tsx`, `GitHubSyncDialog.tsx`, `ResumeImportDialog.tsx`, `SaveVersionDialog.tsx`, `VersionHistoryDialog.tsx`) lacked `aria-label` attributes and their internal ligature icons lacked `aria-hidden="true"`. This is a widespread pattern in modals and dialogs across this application that severely impacts accessibility.
+**Action:** When implementing or modifying dialogs, always ensure close buttons and other icon-only buttons have descriptive `aria-label`s and hide the decorative ligature `<span>` elements with `aria-hidden="true"`.

--- a/components/GitHubSyncDialog.tsx
+++ b/components/GitHubSyncDialog.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { secureApiCall, getAuthToken } from '../utils/security';
@@ -127,7 +126,7 @@ async function fetchGitHubRepositories(): Promise<GitHubRepository[]> {
  * Allows users to sync their GitHub repositories to their resume.
  * Checks OAuth connection status and prompts connection if needed.
  */
- 
+
 export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
   isOpen,
   onClose,
@@ -294,8 +293,11 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
             onClick={onClose}
             className="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
             disabled={isSyncing || isConnecting}
+            aria-label="Close dialog"
           >
-            <span className="material-symbols-outlined">close</span>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              close
+            </span>
           </button>
         </div>
 

--- a/components/ResumeImportDialog.tsx
+++ b/components/ResumeImportDialog.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useRef, useEffect } from 'react';
 import { SimpleResumeData, LinkedInProfile, GitHubRepository } from '../types';
 import { importFromLinkedInFile } from '../utils/import';
@@ -18,12 +17,7 @@ import {
   transformFileImportData,
   buildImportedDataFromOAuth,
 } from './linkedin-import-helpers';
-import {
-  UploadStep,
-  ImportStep,
-  ProjectsStep,
-  CompleteStep,
-} from './LinkedInImportDialog.steps';
+import { UploadStep, ImportStep, ProjectsStep, CompleteStep } from './LinkedInImportDialog.steps';
 import { Step, STEPS } from './useLinkedInImportState';
 
 interface LinkedInImportDialogProps {
@@ -304,8 +298,11 @@ export const LinkedInImportDialog: React.FC<LinkedInImportDialogProps> = ({
             onClick={onClose}
             className="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
             disabled={isImporting}
+            aria-label="Close dialog"
           >
-            <span className="material-symbols-outlined">close</span>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              close
+            </span>
           </button>
         </div>
 
@@ -389,9 +386,7 @@ export const LinkedInImportDialog: React.FC<LinkedInImportDialogProps> = ({
             />
           )}
 
-          {currentStep === 'complete' && (
-            <CompleteStep onClose={onClose} />
-          )}
+          {currentStep === 'complete' && <CompleteStep onClose={onClose} />}
 
           {currentStep === 'upload' && importMethod === 'file' && (
             <div

--- a/components/editor/SaveVersionDialog.tsx
+++ b/components/editor/SaveVersionDialog.tsx
@@ -30,8 +30,11 @@ export const SaveVersionDialog: React.FC<SaveVersionDialogProps> = ({
           <button
             onClick={onClose}
             className="p-2 text-slate-400 hover:bg-slate-100 rounded-lg transition-colors"
+            aria-label="Close dialog"
           >
-            <span className="material-symbols-outlined text-2xl">close</span>
+            <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+              close
+            </span>
           </button>
         </div>
         <div className="p-6">

--- a/components/editor/VersionHistoryDialog.tsx
+++ b/components/editor/VersionHistoryDialog.tsx
@@ -28,8 +28,11 @@ export const VersionHistoryDialog: React.FC<VersionHistoryDialogProps> = ({
           <button
             onClick={onClose}
             className="p-2 text-slate-400 hover:bg-slate-100 rounded-lg transition-colors"
+            aria-label="Close dialog"
           >
-            <span className="material-symbols-outlined text-2xl">close</span>
+            <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+              close
+            </span>
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-6">

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTheme } from '../hooks/useTheme';
 import { toast } from 'react-toastify';
@@ -346,8 +345,13 @@ const Settings: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <h2 className="text-slate-800 font-bold text-xl">Settings</h2>
         <div className="flex items-center gap-4">
-          <button className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <button
+            className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative"
+            aria-label="Notifications"
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </button>
           <div
@@ -878,8 +882,11 @@ const Settings: React.FC = () => {
               <button
                 onClick={handleCloseCreateModal}
                 className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Close dialog"
               >
-                <span className="material-symbols-outlined">close</span>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  close
+                </span>
               </button>
             </div>
 
@@ -1054,8 +1061,11 @@ const Settings: React.FC = () => {
                   setEditingWebhook(undefined);
                 }}
                 className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Close dialog"
               >
-                <span className="material-symbols-outlined">close</span>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  close
+                </span>
               </button>
             </div>
 


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to icon-only close buttons across various dialogs and settings pages, and added `aria-hidden="true"` to their internal Material Symbol ligature `<span>`s.

🎯 Why: Icon-only buttons lacking `aria-label`s are inaccessible to screen readers. Furthermore, when using text-based ligature icon fonts like Material Symbols without `aria-hidden="true"`, screen readers will confusingly read out the ligature text (e.g., "close").

📸 Before/After: Visuals remain unchanged. Screen readers now correctly read "Close dialog" or "Notifications" instead of reading "close" or ignoring the element altogether.

♿ Accessibility: Ensures that screen reader users can interact with modals and settings buttons confidently and without confusing ligature text being read aloud.

---
*PR created automatically by Jules for task [10382957106691861543](https://jules.google.com/task/10382957106691861543) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only buttons across settings and dialog components.

New Features:
- Add descriptive aria-labels to icon-only notification and close buttons in settings and various dialogs to make them identifiable to assistive technologies.

Enhancements:
- Hide decorative Material Symbols ligature spans from screen readers with aria-hidden to prevent redundant or confusing announcements.
- Document the accessibility pattern for icon-only buttons and ligature icons in the palette guidance file for future dialog implementations.