### PR TITLE
🎨 Palette: Add accessible states and focus styles to OfferComparison tabs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2024-04-23 - Accessible Custom Tabs
+**Learning:** Custom tab buttons styled with classes (e.g. `border-b-2`) don't naturally convey their active state to screen readers. Relying purely on visual cues like primary colors or borders is an accessibility anti-pattern.
+**Action:** When implementing custom toggle or tab buttons, always include `aria-current="true"` (for tabs) or `aria-pressed="true"` (for toggles) on the active element. Also ensure they have explicit `:focus-visible` styles (`focus-visible:outline-none focus-visible:ring-2`) to support keyboard navigation without breaking mouse click aesthetics.

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -39,7 +39,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
       <div className="flex gap-2 border-b border-slate-200">
         <button
           onClick={() => setActiveTab('overview')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'overview' ? 'true' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'overview'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -49,7 +50,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('details')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'details' ? 'true' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'details'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -59,7 +61,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('analysis')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'analysis' ? 'true' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'analysis'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'


### PR DESCRIPTION
Added `aria-current` attributes to the custom tabs in the `OfferComparison` component to properly announce the active state to screen readers. Also added explicit `:focus-visible` styles to ensure keyboard navigation is visible and accessible. Updated the palette journal with this learning.

---
*PR created automatically by Jules for task [16060658476920722700](https://jules.google.com/task/16060658476920722700) started by @anchapin*

## Summary by Sourcery

Improve accessibility of OfferComparison tabs and document the pattern in the palette journal.

Enhancements:
- Expose the active state of OfferComparison tab buttons via aria-current attributes and add focus-visible styles for keyboard users.

Documentation:
- Document accessible custom tab patterns and ARIA usage in the palette journal.