### PR TITLE
🎨 Palette: Improve accessibility of ResumePreview zoom controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2024-05-20 - Adding dynamic screen reader announcements for zoom levels
+**Learning:** When creating zoom controls (like Zoom In/Out buttons) that update a visual percentage indicator, screen reader users miss the feedback of the new zoom level unless the percentage display is marked as a live region.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` to the display elements that show dynamically updating values controlled by adjacent buttons, ensuring the new value is announced upon interaction.

--- a/components/ResumePreview.tsx
+++ b/components/ResumePreview.tsx
@@ -268,20 +268,30 @@ const ResumePreview = React.memo<ResumePreviewProps>(
             {/* Zoom Controls */}
             <button
               onClick={() => setPreviewZoom(Math.max(0.5, previewZoom - 0.1))}
-              className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
+              className="p-1.5 hover:bg-slate-100 rounded text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
               title="Zoom Out"
+              aria-label="Zoom Out"
             >
-              <span className="material-symbols-outlined text-lg">remove</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">
+                remove
+              </span>
             </button>
-            <span className="text-xs font-medium text-slate-600 min-w-[3rem] text-center">
+            <span
+              className="text-xs font-medium text-slate-600 min-w-[3rem] text-center"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               {Math.round(previewZoom * 100)}%
             </span>
             <button
               onClick={() => setPreviewZoom(Math.min(2.0, previewZoom + 0.1))}
-              className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
+              className="p-1.5 hover:bg-slate-100 rounded text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
               title="Zoom In"
+              aria-label="Zoom In"
             >
-              <span className="material-symbols-outlined text-lg">add</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">
+                add
+              </span>
             </button>
 
             <div className="h-4 w-px bg-slate-300 mx-2"></div>
@@ -291,10 +301,10 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               <button
                 onClick={onGeneratePDF}
                 disabled={isGeneratingPDF}
-                className="flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white text-xs font-bold rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white text-xs font-bold rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 title="Download PDF"
               >
-                <span className="material-symbols-outlined text-sm">
+                <span className="material-symbols-outlined text-sm" aria-hidden="true">
                   {isGeneratingPDF ? 'hourglass_empty' : 'download'}
                 </span>
                 {isGeneratingPDF ? 'Generating...' : 'PDF'}


### PR DESCRIPTION
**💡 What:** Improved the accessibility and UX of the `ResumePreview` zoom toolbar.
**🎯 Why:** Screen reader users needed descriptive labels for the icon-only zoom buttons. The zoom percentage display updated visually but was not announced dynamically, leaving non-visual users unaware of the new scale.
**♿ Accessibility:**
- Added `aria-label` to Zoom In/Out buttons.
- Added `aria-hidden="true"` to Material Symbols spans to eliminate repetitive announcements.
- Turned the zoom percentage text into a live region (`aria-live="polite"`, `aria-atomic="true"`) to announce the new percentage when changed.
- Improved keyboard navigability by adding `focus-visible:ring` to interactive buttons.

---
*PR created automatically by Jules for task [17485020502935252398](https://jules.google.com/task/17485020502935252398) started by @anchapin*

## Summary by Sourcery

Improve accessibility and keyboard usability of the ResumePreview zoom controls and related toolbar actions.

New Features:
- Announce zoom percentage changes via a live region on the zoom level display.

Enhancements:
- Add aria-labels and hide decorative icons from screen readers for zoom and PDF download controls.
- Improve keyboard focus visibility for zoom and PDF download buttons with focus-visible ring styles.

Documentation:
- Document accessibility patterns for zoom controls and dynamic announcements in the palette guidelines.