### PR TITLE
🎨 Palette: Add accessible states to custom tabs and toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-04-26 - Accessible States for Custom Tabs and Toggles
+**Learning:** Many custom interactive elements like custom tabs and toggle buttons visually indicate their state via CSS but fail to announce this active state to screen readers. For example, tabs using `border-b-2` to show selection did not use ARIA attributes, leaving screen reader users without context of which tab was currently selected.
+**Action:** Always ensure that custom tabs utilize `aria-current="page"` (or similar appropriate values depending on context) and toggle buttons use `aria-pressed="true"` or `aria-pressed="false"`. These additions directly translate visual state into semantic state for assistive technologies. Additionally, ensure keyboard accessibility with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` so keyboard users can easily identify focus.

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -39,7 +39,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
       <div className="flex gap-2 border-b border-slate-200">
         <button
           onClick={() => setActiveTab('overview')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'overview' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm ${
             activeTab === 'overview'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -49,7 +50,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('details')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'details' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm ${
             activeTab === 'details'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -59,7 +61,8 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
         </button>
         <button
           onClick={() => setActiveTab('analysis')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          aria-current={activeTab === 'analysis' ? 'page' : undefined}
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm ${
             activeTab === 'analysis'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'

--- a/components/VariantComparison.tsx
+++ b/components/VariantComparison.tsx
@@ -73,7 +73,8 @@ const VariantComparison: React.FC = () => {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setCompareMode('side-by-side')}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            aria-pressed={compareMode === 'side-by-side'}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
               compareMode === 'side-by-side'
                 ? 'bg-primary-600 text-white'
                 : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
@@ -83,7 +84,8 @@ const VariantComparison: React.FC = () => {
           </button>
           <button
             onClick={() => setCompareMode('diff')}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            aria-pressed={compareMode === 'diff'}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
               compareMode === 'diff'
                 ? 'bg-primary-600 text-white'
                 : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
@@ -104,7 +106,8 @@ const VariantComparison: React.FC = () => {
             <button
               key={variant.id}
               onClick={() => toggleVariant(variant.id)}
-              className={`flex items-center gap-3 px-4 py-3 rounded-lg border-2 transition-all ${
+              aria-pressed={selectedVariants.includes(variant.id)}
+              className={`flex items-center gap-3 px-4 py-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
                 selectedVariants.includes(variant.id)
                   ? 'border-primary-500 bg-primary-50'
                   : 'border-slate-200 hover:border-slate-300'

--- a/components/editor/EditorTabs.tsx
+++ b/components/editor/EditorTabs.tsx
@@ -17,7 +17,8 @@ export const EditorTabs = React.memo<EditorTabsProps>(({ activeTab, onTabChange 
             <button
               key={tab}
               onClick={() => onTabChange(tab)}
-              className={`pb-3 pt-2 text-sm font-bold border-b-[3px] transition-colors ${
+              aria-current={active ? 'page' : undefined}
+              className={`pb-3 pt-2 text-sm font-bold border-b-[3px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm ${
                 active
                   ? 'border-primary-600 text-slate-900'
                   : 'border-transparent text-slate-500 hover:text-primary-600 hover:border-slate-200'


### PR DESCRIPTION
💡 **What:** Added `aria-current="page"` and `aria-pressed` states to custom tab buttons and view toggles across the application (`EditorTabs`, `OfferComparison`, and `VariantComparison`). Also added `focus-visible:outline-none focus-visible:ring-2` to ensure these elements are clearly identifiable when navigating via keyboard.

🎯 **Why:** Custom interactive elements that rely solely on CSS (like `border-b-2`) to visually indicate their active state do not communicate this state to assistive technologies. Screen reader users would navigate through these tabs without knowing which one is currently selected. Adding the proper ARIA states bridges this gap, making the UI much more accessible.

♿ **Accessibility:**
- Added `aria-current="page"` to tab buttons in `EditorTabs` and `OfferComparison`.
- Added `aria-pressed` to toggle buttons in `VariantComparison`.
- Added explicit `focus-visible` outlines for keyboard users.

---
*PR created automatically by Jules for task [17962440811865054133](https://jules.google.com/task/17962440811865054133) started by @anchapin*

## Summary by Sourcery

Improve accessibility semantics and keyboard focus visibility for custom tab and toggle controls across the app.

New Features:
- Expose active tab state via ARIA on editor and offer comparison tabs.
- Expose pressed state via ARIA on variant comparison toggle controls.

Enhancements:
- Add consistent focus-visible ring styles to custom tab and toggle buttons for better keyboard navigation.
- Document accessibility guidance for custom tabs and toggle buttons in the Palette playbook.