### PR TITLE
⚡ Bolt: Fix N+1 query in list_teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 # Dependency reports
 .unused-deps-report.json
 .deps-audit.json
+venv/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+
+## 2026-04-26 - Optimize list_teams N+1 Queries
+**Learning:** The `list_teams` function executed two separate database queries inside a loop for each team returned (fetching member and resume counts). This created an N+1 query problem, turning an O(1) fetch into O(N) database round-trips.
+**Action:** When counting related items for multiple entities, always pre-fetch the counts in a single batch query. Extract the IDs from the parent entities, and execute a single aggregated query using `func.count()`, `.where(Model.team_id.in_(team_ids))`, and `.group_by(Model.team_id)`. Then map the results to a dictionary for O(1) in-memory retrieval inside the loop.

--- a/resume-api/api/team_routes.py
+++ b/resume-api/api/team_routes.py
@@ -184,18 +184,32 @@ async def list_teams(
         teams = result.scalars().all()
 
         team_responses = []
-        for team in teams:
-            member_count_stmt = select(func.count(TeamMember.id)).where(
-                TeamMember.team_id == team.id
-            )
-            result = await db.execute(member_count_stmt)
-            member_count = result.scalar() or 0
 
-            resume_count_stmt = select(func.count(TeamResume.id)).where(
-                TeamResume.team_id == team.id
+        team_member_counts = {}
+        team_resume_counts = {}
+
+        if teams:
+            team_ids = [team.id for team in teams]
+
+            member_count_stmt = (
+                select(TeamMember.team_id, func.count(TeamMember.id))
+                .where(TeamMember.team_id.in_(team_ids))
+                .group_by(TeamMember.team_id)
             )
-            result = await db.execute(resume_count_stmt)
-            resume_count = result.scalar() or 0
+            member_result = await db.execute(member_count_stmt)
+            team_member_counts = dict(member_result.all())
+
+            resume_count_stmt = (
+                select(TeamResume.team_id, func.count(TeamResume.id))
+                .where(TeamResume.team_id.in_(team_ids))
+                .group_by(TeamResume.team_id)
+            )
+            resume_result = await db.execute(resume_count_stmt)
+            team_resume_counts = dict(resume_result.all())
+
+        for team in teams:
+            member_count = team_member_counts.get(team.id, 0)
+            resume_count = team_resume_counts.get(team.id, 0)
 
             team_responses.append(
                 TeamResponse(


### PR DESCRIPTION
💡 **What:** Refactored the `list_teams` route to batch fetch `member_count` and `resume_count` for all teams at once.
🎯 **Why:** The previous implementation executed two separate `SELECT COUNT` queries inside a loop for every team the user belonged to, creating an N+1 query bottleneck.
📊 **Impact:** Reduces database queries from 1 + 2N to exactly 3 queries, regardless of the number of teams returned.
🔬 **Measurement:** Confirmed via local unit tests (`pytest resume-api/tests/test_teams.py`) and global frontend test suite (`pnpm test run`) that behavior remains identical.

---
*PR created automatically by Jules for task [7989674910023483543](https://jules.google.com/task/7989674910023483543) started by @anchapin*

## Summary by Sourcery

Optimize the list_teams API to avoid N+1 queries when computing team member and resume counts, and document the performance lesson in the Bolt engineering log.

Enhancements:
- Batch-fetch member and resume counts for all teams in list_teams using aggregated queries instead of per-team count queries to remove the N+1 pattern.

Documentation:
- Add a Bolt engineering log entry describing the N+1 issue in list_teams and the adopted batching strategy.