### PR TITLE
🎨 Palette: Add aria-hidden to icon ligatures in ResumeCard

### DIFF
--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    className="material-symbols-outlined text-[18px] font-bold"
+                    aria-hidden="true"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to decorative Material Symbol `<span className="material-symbols-outlined">` elements in the `ResumeCard` component.

🎯 **Why:** Screen readers often erroneously announce the ligature text (e.g., "update", "share", "content_copy") of icon fonts. Since the parent `<Button>` elements already have descriptive `aria-label`s, the inner icon texts cause redundant and confusing auditory noise. Applying `aria-hidden="true"` perfectly obscures the decorational text from assistive technologies.

♿ **Accessibility:** Fixes redundant screen reader announcements for purely visual icon ligatures, improving the clarity of interactive elements for keyboard and AT users.

---
*PR created automatically by Jules for task [2093098008057335076](https://jules.google.com/task/2093098008057335076) started by @anchapin*

## Summary by Sourcery

Bug Fixes:
- Prevent screen readers from announcing decorative icon ligature text in ResumeCard actions by adding aria-hidden to icon spans.