### PR TITLE
🎨 Palette: Improve accessibility of SkillsSection close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+
+## 2024-04-28 - Missing `aria-hidden="true"` on Material Icons
+**Learning:** This application heavily uses `material-symbols-outlined` for icons. Many of these icons were missing the `aria-hidden="true"` attribute. This causes screen readers to unnecessarily read out the ligature text (e.g. "close", "share", "add") which creates a confusing and noisy experience, especially when the icon is already within an interactive element that has an `aria-label`.
+**Action:** Always ensure that decorative or ligature-based icons (like `material-symbols-outlined`) have `aria-hidden="true"` applied to them so they are skipped by screen readers. Furthermore, ensure that when an icon is part of a button and is the only visual content, the button has a descriptive `aria-label` attribute.

--- a/components/editor/SkillsSection.tsx
+++ b/components/editor/SkillsSection.tsx
@@ -41,8 +41,9 @@ export const SkillsSection = React.memo<SkillsSectionProps>(
                   <button
                     onClick={() => onRemoveSkill(skill)}
                     className="hover:text-primary-900 ml-1"
+                    aria-label={`Remove ${skill}`}
                   >
-                    <span className="material-symbols-outlined text-[16px]">close</span>
+                    <span className="material-symbols-outlined text-[16px]" aria-hidden="true">close</span>
                   </button>
                 </span>
               ))}

--- a/tests/components/editor/SkillsSection.test.tsx
+++ b/tests/components/editor/SkillsSection.test.tsx
@@ -83,8 +83,8 @@ describe('SkillsSection', () => {
       const user = userEvent.setup();
       render(<SkillsSection {...defaultProps} onRemoveSkill={onRemoveSkill} />);
 
-      // Find all buttons with name "close" - these are the skill remove buttons
-      const closeButtons = screen.getAllByRole('button', { name: /close/i });
+      // Find all buttons with name starting with "Remove" - these are the skill remove buttons
+      const closeButtons = screen.getAllByRole('button', { name: /^Remove/i });
       // The first close button should be for the first skill (React)
       await user.click(closeButtons[0]);
 


### PR DESCRIPTION
💡 What: Added an `aria-label` to the icon-only "close" button for skills, and marked the visual Material Symbol icon as `aria-hidden="true"`.
🎯 Why: Screen readers were previously reading out the word "close" literal ligature, without context of which skill was being removed. Now it explicitly announces "Remove React", etc., and correctly skips the decorative icon.
♿ Accessibility: Ensures WCAG compliance for Name, Role, Value by providing an accessible name for an icon-only button and hiding decorative ligatures.

---
*PR created automatically by Jules for task [1363360875068358329](https://jules.google.com/task/1363360875068358329) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the skill removal button in the editor and document icon accessibility guidance.

New Features:
- Add descriptive aria-labels to skill removal buttons so screen readers announce which skill will be removed.

Enhancements:
- Mark Material Symbol close icons in skill removal buttons as aria-hidden to prevent redundant screen reader announcements.
- Document accessibility best practices for Material Icons usage in the palette guide.

Tests:
- Update SkillsSection tests to assert the new accessible button name pattern for skill removal.