### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in ExperienceItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2026-05-03 - CI Failures Not Palette's Job
+**Learning:** Found CI pip-audit failures caused by Python dependencies (like anthropic, pytest, python-multipart). Fixing backend CI failures is outside the scope of the Palette persona which focuses on UI and accessibility.
+**Action:** When acting as Palette, ignore backend build / CI issues unless they directly block the frontend changes.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,6 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
-## 2026-05-03 - CI Failures Not Palette's Job
-**Learning:** Found CI pip-audit failures caused by Python dependencies (like anthropic, pytest, python-multipart). Fixing backend CI failures is outside the scope of the Palette persona which focuses on UI and accessibility.
-**Action:** When acting as Palette, ignore backend build / CI issues unless they directly block the frontend changes.
+## 2026-05-03 - ReferenceError: window is not defined in Vitest
+**Learning:** Found a `ReferenceError: window is not defined` in `tests/hooks/useATSCheck.test.ts`. The error happens when rendering a hook using `@testing-library/react` because the test file does not import the `vitest.setup.ts` correctly or specify a DOM environment via a docblock comment like `// @vitest-environment jsdom`.
+**Action:** When creating tests for hooks or UI components, ensure that `@testing-library/react` features have access to a DOM. You can add `// @vitest-environment jsdom` at the top of the test file or modify the test to mock DOM globals.

--- a/components/ExperienceItem.tsx
+++ b/components/ExperienceItem.tsx
@@ -111,7 +111,9 @@ const ExperienceItem = React.memo(
             <div
               className={`p-1 rounded-full transition-transform duration-200 ${isExpanded ? 'rotate-180 bg-slate-100 text-slate-900' : 'text-slate-400 group-hover:bg-slate-100 group-hover:text-slate-600'}`}
             >
-              <span className="material-symbols-outlined">expand_more</span>
+              <span className="material-symbols-outlined" aria-hidden="true">
+                expand_more
+              </span>
             </div>
             <div>
               <h3 className="font-bold text-slate-900 text-lg">{exp.role}</h3>
@@ -125,7 +127,9 @@ const ExperienceItem = React.memo(
               className="p-2 text-slate-400 hover:bg-slate-50 hover:text-slate-700 rounded-lg"
               aria-label="Edit experience"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                edit
+              </span>
             </button>
 
             {isDeleting ? (
@@ -140,7 +144,12 @@ const ExperienceItem = React.memo(
                   className="p-1.5 text-red-600 hover:bg-red-50 rounded-md transition-colors"
                   aria-label="Confirm delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    className="material-symbols-outlined text-[18px] font-bold"
+                    aria-hidden="true"
+                  >
+                    check
+                  </span>
                 </button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <button
@@ -151,7 +160,9 @@ const ExperienceItem = React.memo(
                   className="p-1.5 text-slate-400 hover:bg-slate-100 rounded-md transition-colors"
                   aria-label="Cancel delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                    close
+                  </span>
                 </button>
               </div>
             ) : (
@@ -164,7 +175,9 @@ const ExperienceItem = React.memo(
                 className="p-2 text-slate-400 hover:bg-red-50 hover:text-red-500 rounded-lg transition-colors"
                 aria-label="Delete experience"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                  delete
+                </span>
               </button>
             )}
           </div>
@@ -256,7 +269,9 @@ const ExperienceItem = React.memo(
                         className="hover:text-primary-900"
                         aria-label={`Remove tag ${tag}`}
                       >
-                        <span className="material-symbols-outlined text-[14px]">close</span>
+                        <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+                          close
+                        </span>
                       </button>
                     </span>
                   ))}

--- a/tests/hooks/useATSCheck.test.ts
+++ b/tests/hooks/useATSCheck.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useATSCheck } from '../../src/hooks/useATSCheck';


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-hidden="true"` to `material-symbols-outlined` spans within `ExperienceItem.tsx`.
🎯 Why: The user problem it solves: Prevents screen readers from reading the icon font ligatures (like "edit", "close") in addition to the button's `aria-label`.
📸 Before/After: Visuals remained identical.
♿ Accessibility: Reduces auditory clutter and creates a more intuitive navigation experience for screen reader users.

---
*PR created automatically by Jules for task [17720218757566345266](https://jules.google.com/task/17720218757566345266) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Improve accessibility of ExperienceItem controls by hiding decorative icon ligatures from assistive technologies.