### PR TITLE
🛡️ Sentinel: [HIGH] Remove unsafe-eval from CSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 # Dependency reports
 .unused-deps-report.json
 .deps-audit.json
+venv/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,7 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+## 2026-05-03 - Removed `unsafe-eval` from CSP in FastAPI middleware
+**Vulnerability:** The FastAPI `SecurityHeadersMiddleware` in `resume-api/main.py` included `'unsafe-eval'` in the `script-src` directive of the Content Security Policy (CSP).
+**Learning:** Permitting `unsafe-eval` allows the execution of strings as code (e.g., using `eval()`, `setTimeout(string)`, or `new Function(string)`), which severely weakens the CSP and creates a significant Cross-Site Scripting (XSS) risk if any user input is improperly handled.
+**Prevention:** Strictly avoid adding `'unsafe-eval'` to the CSP `script-src` directive. Ensure the application is designed to not rely on dynamic evaluation of code.

--- a/resume-api/main.py
+++ b/resume-api/main.py
@@ -76,7 +76,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Content Security Policy
         csp = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            "script-src 'self' 'unsafe-inline'; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: https:; "
             "font-src 'self' data:; "


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Remove unsafe-eval from CSP

**Severity:** HIGH
**Vulnerability:** The Content Security Policy (CSP) header included the `'unsafe-eval'` directive in the `script-src`, allowing the browser to execute strings as JavaScript code (e.g., via `eval()`, `setTimeout(string)`, etc.).
**Impact:** This severely weakened the XSS protection of the application. If an attacker could inject a malicious string that is later passed to an evaluation function, the browser would execute it.
**Fix:** Removed `'unsafe-eval'` from the `script-src` directive in `resume-api/main.py`.
**Verification:** Verified that tests pass (`pnpm test run`) with the new, stricter CSP.

---
*PR created automatically by Jules for task [15174018046460710865](https://jules.google.com/task/15174018046460710865) started by @anchapin*

## Summary by Sourcery

Tighten the API's Content Security Policy by removing support for dynamic script evaluation and document the associated security change in Sentinel notes.

Enhancements:
- Remove the 'unsafe-eval' directive from the FastAPI middleware CSP configuration to strengthen XSS protections.

Documentation:
- Add a Sentinel security entry describing the risks of 'unsafe-eval' in CSP and guidance to avoid it.