### PR TITLE
🎨 Palette: Fix PasswordStrengthMeter styles and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,7 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+
+## 2024-05-24 - Password Strength Meter Accessibility
+**Learning:** Dynamic visual indicators (like password strength meters) and progress bars need semantic roles and live regions to be perceivable by screen readers. Furthermore, template literal strings in JSX must use backticks, otherwise variables won't interpolate, leading to broken visual styles.
+**Action:** Always use `role="progressbar"` with appropriate `aria-valuenow`/`aria-valuetext` attributes for visual bars, and wrap dynamic text feedback in `aria-live="polite"` containers so users are notified of state changes without losing focus.

--- a/components/PasswordStrengthMeter.tsx
+++ b/components/PasswordStrengthMeter.tsx
@@ -54,16 +54,22 @@ export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ pa
   if (!strength.label) return null;
 
   return (
-    <div className="mt-2">
+    <div className="mt-2" aria-live="polite" aria-atomic="true">
       <div className="flex items-center justify-between mb-1">
         <span className="text-xs font-medium text-slate-600">Password Strength:</span>
-        <span className={'text-xs font-bold text-white px-2 py-0.5 rounded {strength.color}'}>
+        <span className={`text-xs font-bold text-white px-2 py-0.5 rounded ${strength.color}`}>
           {strength.label}
         </span>
       </div>
       <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
         <div
-          className={'h-full transition-all duration-300 {strength.color}'}
+          role="progressbar"
+          aria-valuenow={strength.score}
+          aria-valuemin={0}
+          aria-valuemax={5}
+          aria-valuetext={strength.label}
+          aria-label="Password strength"
+          className={`h-full transition-all duration-300 ${strength.color}`}
           style={{ width: `${(strength.score / 5) * 100}%` }}
         />
       </div>


### PR DESCRIPTION
🎨 Palette: Fix PasswordStrengthMeter styles and accessibility

💡 What: Fixed broken template literals causing dynamic colors to fail in the PasswordStrengthMeter component, and added `role="progressbar"`, `aria-value*`, and `aria-live="polite"` to the container.
🎯 Why: Without backticks, the color strings weren't evaluated, leading to missing styling. The lack of `role` and `aria-live` meant screen readers would not proactively announce the change in password strength to visually impaired users.
♿ Accessibility: Ensures the visual bar is read correctly by screen readers as a progress bar, and any textual update to the score label is read aloud dynamically.

---
*PR created automatically by Jules for task [15042802511326983204](https://jules.google.com/task/15042802511326983204) started by @anchapin*

## Summary by Sourcery

Improve the PasswordStrengthMeter’s visual feedback and accessibility semantics.

Bug Fixes:
- Restore dynamic strength color styling by correctly interpolating the strength.color class in JSX template literals.

Enhancements:
- Expose the password strength bar as an accessible progress bar with appropriate ARIA attributes and live-region announcements for screen readers.
- Document accessibility learnings and guidelines for password strength meters in the Palette accessibility notes.