### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure password hashing for shared resumes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2025-02-27 - [Insecure Password Hashing]
+**Vulnerability:** `advanced_routes.py` used `hashlib.sha256()` without a salt to hash shared resume passwords.
+**Learning:** Raw fast hashing algorithms like SHA256 are susceptible to dictionary and rainbow table attacks. Always use adaptive algorithms like bcrypt for passwords.
+**Prevention:** Use the centralized `config.security.hash_password` and `verify_password` utilities for all password handling.

--- a/resume-api/api/advanced_routes.py
+++ b/resume-api/api/advanced_routes.py
@@ -61,6 +61,7 @@ from database import (
     UserSettings,
 )
 from config.dependencies import AuthorizedAPIKey, rate_limit
+from config.security import hash_password, verify_password
 from lib.utils.validators import validate_resume_data
 from lib.utils.cache import cached
 from lib.utils.cache_integration import CacheInvalidationHook
@@ -824,9 +825,7 @@ async def share_resume(
 
         # Hash password if provided
         if request.password:
-            import hashlib
-
-            share.share_password_hash = hashlib.sha256(request.password.encode()).hexdigest()
+            share.share_password_hash = hash_password(request.password)
 
         db.add(share)
 
@@ -907,10 +906,8 @@ async def access_shared_resume(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Password required",
                 )
-            import hashlib
 
-            password_hash = hashlib.sha256(password.encode()).hexdigest()
-            if password_hash != share.share_password_hash:
+            if not verify_password(password, share.share_password_hash):
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid password",


### PR DESCRIPTION
Replaced insecure `hashlib.sha256()` logic with secure, salted `bcrypt` hashing (via `config.security`) for shared resume passwords. Added a corresponding security learning to the Sentinel journal.

---
*PR created automatically by Jules for task [1909991619576469352](https://jules.google.com/task/1909991619576469352) started by @anchapin*

## Summary by Sourcery

Secure shared resume password handling and document the related security learning.

Bug Fixes:
- Replace insecure unsalted SHA-256 password hashing for shared resumes with secure password hashing using centralized security utilities.

Enhancements:
- Use shared password hashing and verification helpers to centralize resume sharing authentication logic.

Documentation:
- Add a Sentinel security journal entry describing the insecure password hashing vulnerability and its remediation.