### PR TITLE
🎨 Palette: Accessible custom checkboxes in GitHubSyncDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-03-09 - Accessible Custom Checkbox Cards
+**Learning:** When using custom `div` elements as selectable list items or cards instead of native inputs, keyboard users and screen readers lose functionality. This is a recurring issue where `onClick` is added to a `div` without corresponding accessibility attributes.
+**Action:** When implementing custom interactive cards that act as checkboxes, always ensure they have `role="checkbox"`, `aria-checked`, `tabIndex={0}`, explicit `:focus-visible` styles, and an `onKeyDown` handler that triggers the action on 'Enter' and ' ' (Space) keys.

--- a/components/GitHubSyncDialog.tsx
+++ b/components/GitHubSyncDialog.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { secureApiCall, getAuthToken } from '../utils/security';
@@ -127,7 +126,7 @@ async function fetchGitHubRepositories(): Promise<GitHubRepository[]> {
  * Allows users to sync their GitHub repositories to their resume.
  * Checks OAuth connection status and prompts connection if needed.
  */
- 
+
 export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
   isOpen,
   onClose,
@@ -294,8 +293,11 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
             onClick={onClose}
             className="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
             disabled={isSyncing || isConnecting}
+            aria-label="Close dialog"
           >
-            <span className="material-symbols-outlined">close</span>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              close
+            </span>
           </button>
         </div>
 
@@ -391,8 +393,17 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
                     <div
                       key={repo.id}
                       onClick={() => toggleRepository(repo.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          toggleRepository(repo.id);
+                        }
+                      }}
+                      role="checkbox"
+                      aria-checked={selectedRepositories.has(repo.id)}
+                      tabIndex={0}
                       className={`
-                      p-4 rounded-lg border-2 cursor-pointer transition-all
+                      p-4 rounded-lg border-2 cursor-pointer transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
                       ${
                         selectedRepositories.has(repo.id)
                           ? 'border-primary-500 bg-primary-50'


### PR DESCRIPTION
🎨 Palette has improved the accessibility of the `GitHubSyncDialog`!

**💡 What:**
- Added `aria-label="Close dialog"` to the modal close button and hid the internal material symbols icon (`aria-hidden="true"`).
- Upgraded the custom `div`-based repository selection list into fully accessible custom checkboxes.

**🎯 Why:**
- Screen readers were likely reading out the ligature text ("close") without context for the close button.
- Keyboard users could not navigate or toggle the repositories in the list because the interactive elements lacked `tabIndex`, keydown listeners (for Space/Enter), and role definitions.

**♿ Accessibility:**
- Added `role="checkbox"`, `aria-checked`, and `tabIndex={0}` to the repository cards.
- Added an `onKeyDown` handler to toggle repositories when users press 'Enter' or 'Space'.
- Added explicit `focus-visible:ring-2` styles so keyboard users can see which repository they are currently focused on.

---
*PR created automatically by Jules for task [5836834465524511648](https://jules.google.com/task/5836834465524511648) started by @anchapin*