### PR TITLE
🎨 Palette: Add ARIA roles to Password Strength Meter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2026-05-15 - Password Strength Meter Accessibility
+**Learning:** Visual indicators of password strength often rely purely on CSS colors and widths, which are invisible to screen readers. Furthermore, as the strength changes dynamically on input, assistive technologies are not notified of the change.
+**Action:** Always add `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to the visual strength bar. Also, wrap the text label in an `aria-live="polite"` and `aria-atomic="true"` container so the updated strength is announced.

--- a/components/PasswordStrengthMeter.tsx
+++ b/components/PasswordStrengthMeter.tsx
@@ -55,13 +55,20 @@ export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ pa
 
   return (
     <div className="mt-2">
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex items-center justify-between mb-1" aria-live="polite" aria-atomic="true">
         <span className="text-xs font-medium text-slate-600">Password Strength:</span>
         <span className={'text-xs font-bold text-white px-2 py-0.5 rounded {strength.color}'}>
           {strength.label}
         </span>
       </div>
-      <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
+      <div
+        className="h-1 bg-slate-200 rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={strength.score}
+        aria-valuemin={0}
+        aria-valuemax={5}
+        aria-label="Password strength"
+      >
         <div
           className={'h-full transition-all duration-300 {strength.color}'}
           style={{ width: `${(strength.score / 5) * 100}%` }}


### PR DESCRIPTION
### 💡 What:
Added ARIA attributes to the visual password strength meter and text label in `PasswordStrengthMeter.tsx`.

### 🎯 Why:
Visual indicators of password strength often rely purely on CSS colors and widths, which are invisible to screen readers. Furthermore, as the strength changes dynamically on input, assistive technologies are not notified of the change, leaving screen reader users without feedback on their password's strength.

### ♿ Accessibility:
- Added `role="progressbar"` to the visual meter.
- Added `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to dynamically report the current score out of 5.
- Wrapped the strength text label in an `aria-live="polite"` and `aria-atomic="true"` container to announce strength changes dynamically as the user types.

---
*PR created automatically by Jules for task [18226559649371357679](https://jules.google.com/task/18226559649371357679) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the password strength meter by exposing its state to assistive technologies and documenting the pattern.

New Features:
- Expose password strength as an ARIA progressbar with labeled value range for screen readers.

Enhancements:
- Announce password strength text updates via an aria-live region to provide dynamic feedback for assistive technologies.
- Document the password strength meter accessibility pattern and required ARIA attributes in the Palette accessibility guide.

Documentation:
- Extend the Palette accessibility notes with guidance on implementing an accessible password strength meter.