### PR TITLE
🎨 Palette: Fix password strength meter color and add a11y support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,6 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+## 2026-05-17 - Visual Progress Bars Accessibility
+**Learning:** Found an issue where the `PasswordStrengthMeter` visual progress bar lacked screen reader accessibility. Purely visual indicators (like width styling on a `div`) need ARIA roles and live regions to communicate state changes to assistive technologies.
+**Action:** When implementing visual progress bars or dynamically updating strength meters, assign `role="progressbar"` and the corresponding `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` attributes to the visual indicator container. Wrap text announcements in an `aria-live="polite"` and `aria-atomic="true"` container to ensure screen readers announce updates dynamically.

--- a/components/PasswordStrengthMeter.tsx
+++ b/components/PasswordStrengthMeter.tsx
@@ -57,13 +57,24 @@ export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ pa
     <div className="mt-2">
       <div className="flex items-center justify-between mb-1">
         <span className="text-xs font-medium text-slate-600">Password Strength:</span>
-        <span className={'text-xs font-bold text-white px-2 py-0.5 rounded {strength.color}'}>
+        <span
+          className={`text-xs font-bold text-white px-2 py-0.5 rounded ${strength.color}`}
+          aria-live="polite"
+          aria-atomic="true"
+        >
           {strength.label}
         </span>
       </div>
-      <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
+      <div
+        className="h-1 bg-slate-200 rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={strength.score}
+        aria-valuemin={0}
+        aria-valuemax={5}
+        aria-label="Password strength"
+      >
         <div
-          className={'h-full transition-all duration-300 {strength.color}'}
+          className={`h-full transition-all duration-300 ${strength.color}`}
           style={{ width: `${(strength.score / 5) * 100}%` }}
         />
       </div>


### PR DESCRIPTION
💡 What: Added appropriate ARIA attributes to the `PasswordStrengthMeter` component and fixed a bug where template literals were not properly evaluating the color prop.

🎯 Why: The purely visual password strength progress bar lacked accessible context. Screen reader users would not be able to identify its state without a `progressbar` role or know when it changed without an `aria-live` region.

📸 Before/After: Visual regression is fixed (dynamic colors are restored) and accessibility is dramatically improved for assistive technology users.

♿ Accessibility:
- Added `role="progressbar"` to the visual meter.
- Added `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label` to dynamically represent the password strength score.
- Added `aria-live="polite"` and `aria-atomic="true"` to the text label so strength updates are announced immediately as the user types.

---
*PR created automatically by Jules for task [12911959156657367554](https://jules.google.com/task/12911959156657367554) started by @anchapin*

## Summary by Sourcery

Improve accessibility and visual behavior of the password strength meter component.

New Features:
- Add ARIA progressbar semantics and live region support to the password strength meter for screen reader users.

Bug Fixes:
- Fix incorrect template literal usage so the password strength color is applied correctly to the label and progress bar.

Documentation:
- Document accessibility learnings and best practices for visual progress bars and dynamic strength meters in the Jules palette notes.