### PR TITLE
🎨 Palette: [UX improvement] Enhance screen reader accessibility for Resume Preview zoom controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-05-18 - Announcing Dynamic Content Changes Next to Controls
+**Learning:** Found an issue where the zoom percentage display text inside the resume preview viewer updated visually when zoom controls were clicked, but the change was not announced to screen readers. This leaves users navigating via keyboard/screen reader unaware that their action successfully changed the view state.
+**Action:** Always add `aria-live="polite"` and `aria-atomic="true"` to text or span elements that display dynamically updating values (like a zoom percentage, page number, or strength meter) adjacent to the interactive controls that modify them.

--- a/components/ResumePreview.tsx
+++ b/components/ResumePreview.tsx
@@ -270,18 +270,28 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               onClick={() => setPreviewZoom(Math.max(0.5, previewZoom - 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom Out"
+              aria-label="Zoom out"
             >
-              <span className="material-symbols-outlined text-lg">remove</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">
+                remove
+              </span>
             </button>
-            <span className="text-xs font-medium text-slate-600 min-w-[3rem] text-center">
+            <span
+              className="text-xs font-medium text-slate-600 min-w-[3rem] text-center"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               {Math.round(previewZoom * 100)}%
             </span>
             <button
               onClick={() => setPreviewZoom(Math.min(2.0, previewZoom + 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom In"
+              aria-label="Zoom in"
             >
-              <span className="material-symbols-outlined text-lg">add</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">
+                add
+              </span>
             </button>
 
             <div className="h-4 w-px bg-slate-300 mx-2"></div>


### PR DESCRIPTION
**💡 What:**
Added `aria-label="Zoom in"` and `aria-label="Zoom out"` to the zoom controls in `ResumePreview.tsx`. Hid the ligature icons from screen readers using `aria-hidden="true"`. Also added `aria-live="polite"` and `aria-atomic="true"` to the adjacent span displaying the zoom percentage.

**🎯 Why:**
When a screen reader user navigated to the zoom buttons, they would just hear the ligature text "remove" or "add". Even worse, when they clicked the buttons, the zoom percentage updated visually, but they received no feedback that their action was successful. Adding `aria-live` ensures the new percentage is announced immediately after interaction.

**📸 Before/After:**
*(Visuals remain unchanged, screen reader experience improved)*

**♿ Accessibility:**
Improves screen reader context for icon buttons and provides immediate feedback for dynamically changing display values connected to interactive controls.

---
*PR created automatically by Jules for task [1554981955759973338](https://jules.google.com/task/1554981955759973338) started by @anchapin*

## Summary by Sourcery

Improve accessibility of resume preview zoom controls and document the pattern in the accessibility playbook.

Enhancements:
- Add descriptive aria-labels and hide ligature icons from screen readers for zoom buttons in ResumePreview.
- Announce zoom percentage changes to assistive technologies using aria-live and aria-atomic on the zoom display.

Documentation:
- Document best practices for announcing dynamic value changes near interactive controls in the Jules palette guide.