### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix argument injection in subprocess.run

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-05-20 - [Argument Injection via Command Options]
+**Vulnerability:** Argument injection where user input starting with '-' is treated as an option flag by command-line tools.
+**Learning:** Command-line tools like 'df', 'ls', and 'rm' can misinterpret user paths starting with hyphens as options, leading to unexpected behavior or security issues.
+**Prevention:** Always use the end-of-options delimiter '--' before variable paths when invoking command-line utilities via subprocess.

--- a/resume-api/lib/utils/ecryptfs_utils.py
+++ b/resume-api/lib/utils/ecryptfs_utils.py
@@ -28,7 +28,7 @@ def is_ecryptfs_path(path: str) -> bool:
     try:
         # Get the filesystem type for the path securely without shell execution
         result = subprocess.run(
-            ["df", "-Th", path],
+            ["df", "-Th", "--", path],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Argument injection where a user-controlled `path` passed to `df` can start with `-` and be interpreted as an option flag.
🎯 **Impact:** Unexpected behavior or errors in command-line utility execution.
🔧 **Fix:** Inserted the end-of-options delimiter `--` before the path variable in `subprocess.run` to ensure paths are strictly treated as positional arguments.
✅ **Verification:** Verified by checking syntax with `py_compile` and manually asserting that `df -Th -- -abc` correctly interprets `-abc` as a file name rather than raising an invalid option error. Ran the test suite to ensure no regressions.

---
*PR created automatically by Jules for task [10955690451660607175](https://jules.google.com/task/10955690451660607175) started by @anchapin*

## Summary by Sourcery

Prevent argument injection in filesystem type checks by hardening subprocess calls and document the vulnerability pattern in Sentinel notes.

Bug Fixes:
- Ensure ecryptfs filesystem checks pass user paths to `df` as positional arguments using the end-of-options delimiter to avoid option injection.

Documentation:
- Document argument injection risks with hyphen-prefixed paths and recommended use of the `--` end-of-options delimiter in Sentinel security notes.