### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in migration_helpers.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,9 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-05-22 - [SQL Injection via String Formatting in SQLAlchemy text() in migration_helpers.py]
+
+**Vulnerability:** The `migrate_table_in_batches` method in `resume-api/lib/db/migration_helpers.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT {id_column} FROM {table_name} ...")`), creating a direct vector for SQL injection if `table_name` or `id_column` are user-controlled.
+**Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
+**Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `.limit(bindparam('limit'))`).

--- a/resume-api/lib/db/migration_helpers.py
+++ b/resume-api/lib/db/migration_helpers.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Callable
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy import text
+from sqlalchemy import text, table, column, select, bindparam
 
 logger = logging.getLogger(__name__)
 
@@ -311,12 +311,18 @@ class BatchMigrationManager:
         while True:
             # Get batch of IDs
             async with self.primary_engine.begin() as conn:
+                # Use SQLAlchemy core objects for safe dynamic query building
+                t = table(table_name, column(id_column))
+                stmt = (
+                    select(column(id_column))
+                    .select_from(t)
+                    .order_by(column(id_column))
+                    .limit(bindparam("limit"))
+                    .offset(bindparam("offset"))
+                )
+
                 result = await conn.execute(
-                    text(f"""
-                        SELECT {id_column} FROM {table_name}
-                        ORDER BY {id_column}
-                        LIMIT :limit OFFSET :offset
-                    """),
+                    stmt,
                     {"limit": self.batch_size, "offset": offset},
                 )
                 rows = result.fetchall()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `migrate_table_in_batches` method in `migration_helpers.py` used an f-string inside `sqlalchemy.text()` for dynamically building a query, which is vulnerable to SQL injection.
🎯 Impact: An attacker could potentially execute arbitrary SQL commands if they can control the `table_name` or `id_column` parameters passed to `migrate_table_in_batches`.
🔧 Fix: Replaced raw string interpolation (`f"SELECT {id_column} FROM {table_name} ..."`) with SQLAlchemy's core objects (`table()`, `column()`, `select()`) to safely construct the query using proper quoting.
✅ Verification: Ran syntax checks via `py_compile` and verified functionality via the test suite (`pnpm test run`).

---
*PR created automatically by Jules for task [1955437952245478909](https://jules.google.com/task/1955437952245478909) started by @anchapin*