### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/components/ResumePreview.tsx
+++ b/components/ResumePreview.tsx
@@ -270,8 +270,9 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               onClick={() => setPreviewZoom(Math.max(0.5, previewZoom - 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom Out"
+              aria-label="Zoom out"
             >
-              <span className="material-symbols-outlined text-lg">remove</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">remove</span>
             </button>
             <span className="text-xs font-medium text-slate-600 min-w-[3rem] text-center">
               {Math.round(previewZoom * 100)}%
@@ -280,8 +281,9 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               onClick={() => setPreviewZoom(Math.min(2.0, previewZoom + 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom In"
+              aria-label="Zoom in"
             >
-              <span className="material-symbols-outlined text-lg">add</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">add</span>
             </button>
 
             <div className="h-4 w-px bg-slate-300 mx-2"></div>

--- a/components/activity/ActivityFeed.tsx
+++ b/components/activity/ActivityFeed.tsx
@@ -43,8 +43,9 @@ export const NotificationsBell: React.FC<NotificationsBellProps> = ({ onOpenPane
       onClick={handleClick}
       className="relative p-2 text-gray-400 hover:text-gray-600 transition"
       title="Notifications"
+      aria-label="Notifications"
     >
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
       </svg>
       {unreadCount > 0 && (
@@ -186,8 +187,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600"
+              aria-label="Close notifications"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
@@ -240,8 +242,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                         onClick={() => handleMarkRead(notification.id)}
                         className="text-gray-400 hover:text-blue-600 p-1"
                         title="Mark as read"
+                        aria-label="Mark as read"
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
                       </button>
@@ -250,8 +253,9 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
                       onClick={() => handleDelete(notification.id)}
                       className="text-gray-400 hover:text-red-600 p-1"
                       title="Delete"
+                      aria-label="Delete notification"
                     >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                       </svg>
                     </button>


### PR DESCRIPTION
💡 What: Added descriptive `aria-label`s to icon-only `<button>` elements in `components/ResumePreview.tsx` (Zoom In/Out) and `components/activity/ActivityFeed.tsx` (Notifications, Close, Mark as read, Delete). Also added `aria-hidden="true"` to their inner `<span>` and `<svg>` decorative elements.
🎯 Why: Icon-only buttons without accessible labels are not announced properly by screen readers, making the application inaccessible to users relying on assistive technologies.
📸 Before/After: Before, buttons like `<button><svg>...</svg></button>` would just read "button". Now, they read "button, Delete notification".
♿ Accessibility: Ensures that screen reader users can understand and interact with icon-only controls across the Activity Feed and Resume Preview components.

---
*PR created automatically by Jules for task [206391946679696369](https://jules.google.com/task/206391946679696369) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only controls in the notifications activity feed and resume preview.

Bug Fixes:
- Make notifications bell, close, mark-as-read, and delete buttons screen-reader accessible by adding descriptive ARIA labels and hiding decorative SVGs from assistive tech.
- Make resume preview zoom in/out controls accessible by adding ARIA labels and marking icon spans as decorative.