### PR TITLE
🎨 Palette: Improve OfferComparison tabs and icon accessibility

### DIFF
--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -36,10 +36,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
   return (
     <div className="space-y-6">
       {/* Tabs */}
-      <div className="flex gap-2 border-b border-slate-200">
+      <div
+        className="flex gap-2 border-b border-slate-200"
+        role="tablist"
+        aria-label="Comparison tabs"
+      >
         <button
+          role="tab"
+          aria-selected={activeTab === 'overview'}
+          aria-controls="panel-overview"
+          id="tab-overview"
           onClick={() => setActiveTab('overview')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'overview'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -48,8 +56,12 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
           Overview
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === 'details'}
+          aria-controls="panel-details"
+          id="tab-details"
           onClick={() => setActiveTab('details')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'details'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -58,8 +70,12 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
           Details
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === 'analysis'}
+          aria-controls="panel-analysis"
+          id="tab-analysis"
           onClick={() => setActiveTab('analysis')}
-          className={`px-4 py-2 font-medium text-sm transition-colors ${
+          className={`px-4 py-2 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-t-lg ${
             activeTab === 'analysis'
               ? 'text-primary-600 border-b-2 border-primary-600'
               : 'text-slate-600 hover:text-slate-900'
@@ -71,12 +87,19 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
 
       {/* Overview Tab */}
       {activeTab === 'overview' && (
-        <div className="space-y-6">
+        <div
+          className="space-y-6"
+          role="tabpanel"
+          id="panel-overview"
+          aria-labelledby="tab-overview"
+        >
           {/* Recommendation Banner */}
           <div className="bg-gradient-to-r from-primary-500 to-primary-600 rounded-xl p-6 text-white">
             <div className="flex items-start gap-4">
               <div className="bg-white/20 size-12 rounded-full flex items-center justify-center flex-shrink-0">
-                <span className="material-symbols-outlined text-2xl">star</span>
+                <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+                  star
+                </span>
               </div>
               <div className="flex-1">
                 <h3 className="font-bold text-lg mb-1">Recommended Offer</h3>
@@ -174,7 +197,7 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
 
       {/* Details Tab */}
       {activeTab === 'details' && (
-        <div className="space-y-6">
+        <div className="space-y-6" role="tabpanel" id="panel-details" aria-labelledby="tab-details">
           {/* Side-by-side Comparison */}
           <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
             <table className="w-full">
@@ -301,7 +324,12 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
 
       {/* Analysis Tab */}
       {activeTab === 'analysis' && (
-        <div className="space-y-6">
+        <div
+          className="space-y-6"
+          role="tabpanel"
+          id="panel-analysis"
+          aria-labelledby="tab-analysis"
+        >
           {comparison.scores.map((score) => {
             const offer = comparison.offers.find((o) => o.id === score.offerId);
             if (!offer) return null;
@@ -344,13 +372,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.pros.length > 0 && (
                     <div className="bg-green-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-green-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_up</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_up
+                        </span>
                         Pros
                       </h5>
                       <ul className="space-y-1">
                         {score.pros.map((pro, idx) => (
                           <li key={idx} className="text-sm text-green-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               check
                             </span>
                             {pro}
@@ -363,13 +396,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.cons.length > 0 && (
                     <div className="bg-red-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-red-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_down</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_down
+                        </span>
                         Cons
                       </h5>
                       <ul className="space-y-1">
                         {score.cons.map((con, idx) => (
                           <li key={idx} className="text-sm text-red-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               close
                             </span>
                             {con}


### PR DESCRIPTION
💡 **What**: Added `role="tablist"`, `role="tab"`, `aria-selected`, `aria-controls`, and focus rings (`focus-visible:ring-2`) to the navigation buttons in `OfferComparison.tsx`. Added `aria-hidden="true"` to all Material Symbols ligatures. Added `role="tabpanel"` and corresponding IDs to the content containers.
🎯 **Why**: To ensure the component's custom tab interface is fully accessible via keyboard navigation and correctly announced by screen readers, resolving issues where decorative ligatures were being announced aloud.
📸 **Before/After**: The UI visually remains the same except for a blue focus ring when navigating via keyboard (tabbing). Screen reader behavior is vastly improved.
♿ **Accessibility**: Significant improvements for keyboard and screen reader users via proper WAI-ARIA tab semantics and decorative icon hiding.

---
*PR created automatically by Jules for task [8843604322218400203](https://jules.google.com/task/8843604322218400203) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the OfferComparison tab interface and icon usage.

Enhancements:
- Add proper WAI-ARIA roles and relationships to OfferComparison tabs and their associated panels.
- Add visible focus styles to tab buttons for better keyboard navigation.
- Mark Material Symbols ligature icons in OfferComparison as decorative using aria-hidden to prevent screen readers from announcing them.