### PR TITLE
🎨 Palette: Improve copy button accessibility

### DIFF
--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect } from 'react';
 import { ErrorContext, ErrorType } from '../utils/errorHandler';
 import { getErrorMessageByType, getErrorSuggestion } from '../utils/errorMessages';
@@ -279,9 +278,10 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
               <button
                 onClick={copyErrorId}
                 className="hover:opacity-100 opacity-50 transition-opacity"
-                title="Copy Error ID"
+                title={copied ? 'Error ID copied' : 'Copy Error ID'}
+                aria-label={copied ? 'Error ID copied' : 'Copy Error ID'}
               >
-                <span className="material-symbols-outlined text-[12px]">
+                <span className="material-symbols-outlined text-[12px]" aria-hidden="true">
                   {copied ? 'check' : 'content_copy'}
                 </span>
               </button>

--- a/components/ShareDialog.tsx
+++ b/components/ShareDialog.tsx
@@ -212,10 +212,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({ isOpen, resumeId, onClose }) 
               />
               <button
                 onClick={handleCopyLink}
-                aria-label="Copy share link"
+                aria-label={copied ? 'Share link copied' : 'Copy share link'}
                 className="px-4 py-2.5 bg-primary-600 text-white font-bold rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2"
               >
-                <span className="material-symbols-outlined text-[20px]">
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
                   {copied ? 'check' : 'content_copy'}
                 </span>
                 {copied ? 'Copied!' : 'Copy'}


### PR DESCRIPTION
💡 What:
Updated copy buttons in `ErrorDisplay.tsx` and `ShareDialog.tsx` to use dynamic `aria-label` attributes based on their copy state, and added `aria-hidden="true"` to their ligature icons.

🎯 Why:
To ensure immediate state feedback is communicated correctly to screen readers without reading ligature text, creating a more accessible copy experience that matches application-wide UX standards.

📸 Before/After:
Before: Icons read incorrectly by screen readers, and no audible confirmation of state changes.
After: Screen readers cleanly announce the copy action and confirm state changes without reciting ligature text.

♿ Accessibility:
Ensures dynamic visual state changes correlate with ARIA state updates. Also ensures ligature text inside icon spans is properly ignored.

---
*PR created automatically by Jules for task [18255166110735799027](https://jules.google.com/task/18255166110735799027) started by @anchapin*

## Summary by Sourcery

Improve accessibility of copy buttons by providing dynamic ARIA labelling and hiding decorative icon ligatures from screen readers.

Enhancements:
- Add state-aware aria-label and title text to the error ID copy button to reflect whether the value has been copied.
- Update the share link copy button to use dynamic aria-label text based on copy state and mark its icon as aria-hidden.
- Mark material icon spans in copy buttons as aria-hidden so screen readers do not announce ligature text.