### PR TITLE
🎨 Palette: Add accessible form error and helper text association

### DIFF
--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -10,6 +10,10 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, error, helperText, leftIcon, className = '', id, ...props }, ref) => {
     const inputId = id || (label ? `input-${label.replace(/\s+/g, '-').toLowerCase()}` : undefined);
+    const helperId = `${inputId}-helper`;
+    const errorId = `${inputId}-error`;
+
+    const ariaDescribedBy = error ? errorId : helperText ? helperId : undefined;
 
     const baseInputStyles =
       'w-full px-4 py-2 rounded-lg border-2 transition-all duration-200 outline-none focus:ring-4 focus:ring-primary-100 text-sm';
@@ -33,12 +37,23 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               {leftIcon}
             </div>
           )}
-          <input ref={ref} id={inputId} className={combinedInputClassName} {...props} />
+          <input
+            ref={ref}
+            id={inputId}
+            className={combinedInputClassName}
+            aria-invalid={!!error}
+            aria-describedby={ariaDescribedBy}
+            {...props}
+          />
         </div>
         {error ? (
-          <p className="text-xs text-red-600 font-medium">{error}</p>
+          <p id={errorId} className="text-xs text-red-600 font-medium">
+            {error}
+          </p>
         ) : helperText ? (
-          <p className="text-xs text-slate-500">{helperText}</p>
+          <p id={helperId} className="text-xs text-slate-500">
+            {helperText}
+          </p>
         ) : null}
       </div>
     );

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -8,7 +8,11 @@ export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElemen
 }
 
 const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className = '', label, error, leftIcon, rightIcon, children, ...props }, ref) => {
+  ({ className = '', label, error, leftIcon, rightIcon, children, id, ...props }, ref) => {
+    const selectId =
+      id || (label ? `select-${label.replace(/\s+/g, '-').toLowerCase()}` : undefined);
+    const errorId = `${selectId}-error`;
+
     const baseStyles =
       'w-full px-4 py-2.5 rounded-lg bg-slate-50 border border-slate-200 focus:bg-white focus:border-primary-500 focus:ring-2 focus:ring-primary-100 outline-none transition-all duration-200 appearance-none text-slate-900 text-sm font-medium disabled:opacity-50 disabled:bg-slate-50 disabled:cursor-not-allowed';
 
@@ -17,7 +21,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <div className="space-y-1.5 w-full">
         {label && (
-          <label className="text-sm font-bold text-slate-700 block px-1" htmlFor={props.id}>
+          <label className="text-sm font-bold text-slate-700 block px-1" htmlFor={selectId}>
             {label}
           </label>
         )}
@@ -29,20 +33,30 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
           )}
           <select
             ref={ref}
+            id={selectId}
             className={`${combinedClassName} ${leftIcon ? 'pl-10' : ''} ${rightIcon ? 'pr-10' : 'pr-10'}`}
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
             {...props}
           >
             {children}
           </select>
           <div className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none">
             {rightIcon || (
-              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">unfold_more</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                unfold_more
+              </span>
             )}
           </div>
         </div>
         {error && (
-          <p className="text-xs font-medium text-red-500 px-1 mt-1 flex items-center gap-1.5">
-            <span className="material-symbols-outlined text-[14px]" aria-hidden="true">error</span>
+          <p
+            id={errorId}
+            className="text-xs font-medium text-red-500 px-1 mt-1 flex items-center gap-1.5"
+          >
+            <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
+              error
+            </span>
             {error}
           </p>
         )}


### PR DESCRIPTION
💡 What: Associated form inputs and selects with their corresponding error and helper text labels using `aria-describedby`, and added `aria-invalid` to indicate error states. Added an ID generator to `Select` similar to `Input` to ensure `htmlFor` targets work correctly.

🎯 Why: This helps screen readers read out error validation messages and helper context directly as users interact with form fields, making the UI much more accessible.

📸 Before/After: Visuals remain unchanged; it's a semantic/accessibility update.

♿ Accessibility: Improved screen reader support for form validations and instructions by explicitly linking form errors/helpers using `aria-describedby` and tagging invalid states with `aria-invalid`.

---
*PR created automatically by Jules for task [7020557756741835725](https://jules.google.com/task/7020557756741835725) started by @anchapin*

## Summary by Sourcery

Improve accessibility of Input and Select components by associating labels, helper text, and error messages with form fields via ARIA attributes and stable IDs.

New Features:
- Add automatic ID generation for the Select component to reliably associate labels and error messages.

Enhancements:
- Wire Input and Select components to use aria-invalid and aria-describedby for error and helper text associations to improve screen reader support.