### PR TITLE
🎨 Palette: Add ARIA labels to ResumePreview zoom buttons

### DIFF
--- a/components/ResumePreview.tsx
+++ b/components/ResumePreview.tsx
@@ -270,8 +270,9 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               onClick={() => setPreviewZoom(Math.max(0.5, previewZoom - 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom Out"
+              aria-label="Zoom Out"
             >
-              <span className="material-symbols-outlined text-lg">remove</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">remove</span>
             </button>
             <span className="text-xs font-medium text-slate-600 min-w-[3rem] text-center">
               {Math.round(previewZoom * 100)}%
@@ -280,8 +281,9 @@ const ResumePreview = React.memo<ResumePreviewProps>(
               onClick={() => setPreviewZoom(Math.min(2.0, previewZoom + 0.1))}
               className="p-1.5 hover:bg-slate-100 rounded text-slate-500"
               title="Zoom In"
+              aria-label="Zoom In"
             >
-              <span className="material-symbols-outlined text-lg">add</span>
+              <span className="material-symbols-outlined text-lg" aria-hidden="true">add</span>
             </button>
 
             <div className="h-4 w-px bg-slate-300 mx-2"></div>
@@ -294,7 +296,7 @@ const ResumePreview = React.memo<ResumePreviewProps>(
                 className="flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white text-xs font-bold rounded hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Download PDF"
               >
-                <span className="material-symbols-outlined text-sm">
+                <span className="material-symbols-outlined text-sm" aria-hidden="true">
                   {isGeneratingPDF ? 'hourglass_empty' : 'download'}
                 </span>
                 {isGeneratingPDF ? 'Generating...' : 'PDF'}


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to the Zoom In and Zoom Out icon-only buttons in the Resume Preview panel, and hid the decorative ligature-based Google Material icons (add, remove, and download/hourglass) from screen readers.

🎯 **Why:** To improve accessibility for screen reader users. Without `aria-label`s, icon-only buttons are unidentifiable. Without `aria-hidden="true"`, screen readers will frustratingly read the literal text used to render the icon (e.g. "Zoom In add button" or just "download PDF button").

📸 **Before/After:** No visual changes. This is purely a semantic HTML update for assistive technologies.

♿ **Accessibility:**
- Added clear, descriptive names to unlabeled interactive elements.
- Cleaned up the accessibility tree by removing decorative text ligatures that create noise for screen reader users.

---
*PR created automatically by Jules for task [14843445127142091918](https://jules.google.com/task/14843445127142091918) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the Resume preview controls by adding ARIA labelling and hiding decorative icons from assistive technologies.

Enhancements:
- Add ARIA labels to the Resume preview zoom controls to provide accessible names for screen reader users.
- Hide decorative Material icon ligatures from screen readers in the Resume preview actions to reduce noise in the accessibility tree.