### PR TITLE
🎨 Palette: [UX improvement] Fix EditorHeader accessibility with semantic button

### DIFF
--- a/components/editor/EditorHeader.tsx
+++ b/components/editor/EditorHeader.tsx
@@ -9,12 +9,16 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({ onNavigate }) => {
 
   return (
     <header className="flex items-center justify-between px-10 py-3 bg-white border-b border-slate-200 sticky top-0 z-30 shadow-sm">
-      <div className="flex items-center gap-4 cursor-pointer" onClick={onNavigate}>
+      <button
+        type="button"
+        className="flex items-center gap-4 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-lg"
+        onClick={onNavigate}
+      >
         <div className="bg-primary-600 size-8 rounded-lg flex items-center justify-center text-white">
-          <span className="material-symbols-outlined text-[18px]">description</span>
+          <span className="material-symbols-outlined text-[18px]" aria-hidden="true">description</span>
         </div>
         <h2 className="text-slate-900 text-lg font-bold">ResumeBuilder SaaS</h2>
-      </div>
+      </button>
       <div className="flex items-center gap-8">
         <nav className="flex gap-6">
           {NAV_ITEMS.map((item) => (


### PR DESCRIPTION
### 💡 What:
Replaced the `div` wrapper acting as a navigation button in `EditorHeader.tsx` with a semantic `<button>` element. Also added `aria-hidden="true"` to the decorative "description" Material Symbol icon.

### 🎯 Why:
Using a `div` for interactive elements breaks keyboard navigation (tabbing) and prevents screen readers from correctly identifying the element as an actionable button. The ligature icon text was also being redundantly announced. This fix ensures standard accessibility practices are met.

### ♿ Accessibility:
- **Keyboard Navigation:** The brand header is now focusable via the `Tab` key and can be activated using the `Enter` or `Space` keys. Added `focus-visible` styles to indicate focus.
- **Screen Reader Support:** The element is now properly announced as a "button" rather than a generic text block. The repetitive "description" text is no longer announced.

---
*PR created automatically by Jules for task [12650054822194160939](https://jules.google.com/task/12650054822194160939) started by @anchapin*

## Summary by Sourcery

Improve accessibility of the editor header brand area by using semantic button markup and refining icon accessibility.

Enhancements:
- Replace the clickable brand container in the editor header with a semantic <button> element to support proper keyboard and screen reader interaction.
- Mark the decorative description icon as aria-hidden and add focus-visible styles to clarify focus on the header button.