### PR TITLE
🎨 Palette: Add aria-hidden to ligature icons and aria-pressed to buttons

### DIFF
--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -76,7 +76,9 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
           <div className="bg-gradient-to-r from-primary-500 to-primary-600 rounded-xl p-6 text-white">
             <div className="flex items-start gap-4">
               <div className="bg-white/20 size-12 rounded-full flex items-center justify-center flex-shrink-0">
-                <span className="material-symbols-outlined text-2xl">star</span>
+                <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+                  star
+                </span>
               </div>
               <div className="flex-1">
                 <h3 className="font-bold text-lg mb-1">Recommended Offer</h3>
@@ -344,13 +346,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.pros.length > 0 && (
                     <div className="bg-green-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-green-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_up</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_up
+                        </span>
                         Pros
                       </h5>
                       <ul className="space-y-1">
                         {score.pros.map((pro, idx) => (
                           <li key={idx} className="text-sm text-green-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               check
                             </span>
                             {pro}
@@ -363,13 +370,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.cons.length > 0 && (
                     <div className="bg-red-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-red-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_down</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_down
+                        </span>
                         Cons
                       </h5>
                       <ul className="space-y-1">
                         {score.cons.map((con, idx) => (
                           <li key={idx} className="text-sm text-red-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               close
                             </span>
                             {con}

--- a/components/TemplateCustomizer.tsx
+++ b/components/TemplateCustomizer.tsx
@@ -61,6 +61,7 @@ export const TemplateCustomizer: React.FC<TemplateCustomizerProps> = ({
                   ? 'border-primary-500 bg-primary-50'
                   : 'border-slate-200 hover:border-slate-300'
               }`}
+              aria-pressed={customization.color_scheme === scheme.name}
             >
               <div className="flex gap-1">
                 <div
@@ -81,7 +82,10 @@ export const TemplateCustomizer: React.FC<TemplateCustomizerProps> = ({
               </div>
               <span className="text-sm font-medium text-slate-700 capitalize">{scheme.name}</span>
               {customization.color_scheme === scheme.name && (
-                <span className="material-symbols-outlined text-primary-600 text-[20px] ml-auto">
+                <span
+                  className="material-symbols-outlined text-primary-600 text-[20px] ml-auto"
+                  aria-hidden="true"
+                >
                   check_circle
                 </span>
               )}
@@ -104,10 +108,14 @@ export const TemplateCustomizer: React.FC<TemplateCustomizerProps> = ({
                     ? 'border-primary-500 bg-primary-50'
                     : 'border-slate-200 hover:border-slate-300'
                 }`}
+                aria-pressed={customization.font === font}
               >
                 <span className="text-sm font-medium text-slate-700 capitalize">{font}</span>
                 {customization.font === font && (
-                  <span className="material-symbols-outlined text-primary-600 text-[20px]">
+                  <span
+                    className="material-symbols-outlined text-primary-600 text-[20px]"
+                    aria-hidden="true"
+                  >
                     check_circle
                   </span>
                 )}
@@ -130,10 +138,14 @@ export const TemplateCustomizer: React.FC<TemplateCustomizerProps> = ({
                   ? 'border-primary-500 bg-primary-50'
                   : 'border-slate-200 hover:border-slate-300'
               }`}
+              aria-pressed={customization.paper_size === size.value}
             >
               <span className="text-sm font-medium text-slate-700">{size.label}</span>
               {customization.paper_size === size.value && (
-                <span className="material-symbols-outlined text-primary-600 text-[20px]">
+                <span
+                  className="material-symbols-outlined text-primary-600 text-[20px]"
+                  aria-hidden="true"
+                >
                   check_circle
                 </span>
               )}
@@ -207,7 +219,9 @@ export const TemplateCustomizer: React.FC<TemplateCustomizerProps> = ({
             onClick={onApply}
             className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium"
           >
-            <span className="material-symbols-outlined text-[20px]">done</span>
+            <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+              done
+            </span>
             Apply Customization
           </button>
         </div>

--- a/components/TemplateSelector.tsx
+++ b/components/TemplateSelector.tsx
@@ -157,7 +157,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                         : 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    <span className="material-symbols-outlined text-[24px]">
+                    <span className="material-symbols-outlined text-[24px]" aria-hidden="true">
                       {getTemplateIcon(template.category)}
                     </span>
                   </div>
@@ -274,13 +274,19 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                     <h4 className="text-sm font-bold text-slate-700 mb-2">Style & Category</h4>
                     <div className="space-y-1">
                       <div className="flex items-center gap-2">
-                        <span className="material-symbols-outlined text-[16px] text-slate-500">
+                        <span
+                          className="material-symbols-outlined text-[16px] text-slate-500"
+                          aria-hidden="true"
+                        >
                           style
                         </span>
                         <span className="text-sm text-slate-700 capitalize">{template.style}</span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <span className="material-symbols-outlined text-[16px] text-slate-500">
+                        <span
+                          className="material-symbols-outlined text-[16px] text-slate-500"
+                          aria-hidden="true"
+                        >
                           category
                         </span>
                         <span className="text-sm text-slate-700 capitalize">
@@ -298,7 +304,9 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                       onClick={() => onPreview(template.name)}
                       className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium"
                     >
-                      <span className="material-symbols-outlined text-[18px]">visibility</span>
+                      <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                        visibility
+                      </span>
                       Preview Template
                     </button>
                   </div>
@@ -312,7 +320,10 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
       {/* Empty State */}
       {filteredTemplates.length === 0 && (
         <div className="text-center py-8 bg-slate-50 rounded-lg">
-          <span className="material-symbols-outlined text-[48px] text-slate-400 mb-2">
+          <span
+            className="material-symbols-outlined text-[48px] text-slate-400 mb-2"
+            aria-hidden="true"
+          >
             folder_open
           </span>
           <p className="text-slate-600">No templates found in this category</p>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative `<span className="material-symbols-outlined">` elements and `aria-pressed` attributes to toggle buttons across `TemplateSelector`, `OfferComparison`, and `TemplateCustomizer`.
🎯 Why: Screen readers were incorrectly announcing the literal text of ligature icons (e.g., reading "thumb_up" or "check_circle"), creating a confusing experience. Adding `aria-hidden` ensures these visual-only icons are ignored by screen readers, while `aria-pressed` provides correct state feedback for selection buttons.
📸 Before/After: No visual changes.
♿ Accessibility: Improved screen reader experience by hiding decorative icons and explicitly communicating the pressed state of interactive toggle elements.

---
*PR created automatically by Jules for task [9208105415405430969](https://jules.google.com/task/9208105415405430969) started by @anchapin*