### PR TITLE
🎨 Palette: Add `aria-hidden` to Material Symbol ligatures

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -93,7 +93,9 @@ export function ErrorFallback({
   return (
     <div className="min-h-[400px] flex flex-col items-center justify-center p-8 bg-red-50/50 border border-red-100 rounded-3xl m-6 shadow-sm">
       <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-6">
-        <span className="material-symbols-outlined text-red-600 text-4xl">bug_report</span>
+        <span className="material-symbols-outlined text-red-600 text-4xl" aria-hidden="true">
+          bug_report
+        </span>
       </div>
 
       <h2 className="text-2xl font-bold text-slate-900 mb-2">Something went wrong</h2>
@@ -110,7 +112,9 @@ export function ErrorFallback({
             onClick={resetError}
             className="w-full py-3 bg-primary-600 text-white font-bold rounded-xl hover:bg-primary-700 transition-all shadow-lg shadow-primary-600/20 flex items-center justify-center gap-2"
           >
-            <span className="material-symbols-outlined text-[20px]">refresh</span>
+            <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+              refresh
+            </span>
             Try Again
           </button>
         )}
@@ -119,7 +123,9 @@ export function ErrorFallback({
           onClick={() => (window.location.href = '/dashboard')}
           className="w-full py-3 bg-white text-slate-700 font-bold rounded-xl border border-slate-200 hover:bg-slate-50 transition-all flex items-center justify-center gap-2"
         >
-          <span className="material-symbols-outlined text-[20px]">home</span>
+          <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+            home
+          </span>
           Back to Dashboard
         </button>
 
@@ -128,7 +134,7 @@ export function ErrorFallback({
           className="mt-4 text-xs font-bold text-slate-400 uppercase tracking-widest hover:text-slate-600 transition-colors flex items-center gap-1"
         >
           {showDetails ? 'Hide' : 'Show'} Technical Details
-          <span className="material-symbols-outlined text-[16px]">
+          <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
             {showDetails ? 'expand_less' : 'expand_more'}
           </span>
         </button>

--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect } from 'react';
 import { ErrorContext, ErrorType } from '../utils/errorHandler';
 import { getErrorMessageByType, getErrorSuggestion } from '../utils/errorMessages';
@@ -268,7 +267,10 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
       aria-label={`${title}: ${error.userMessage}`}
     >
       <div className="flex items-start gap-3">
-        <span className={`material-symbols-outlined ${iconColor} flex-shrink-0 mt-0.5`}>
+        <span
+          className={`material-symbols-outlined ${iconColor} flex-shrink-0 mt-0.5`}
+          aria-hidden="true"
+        >
           {getIcon(error.type)}
         </span>
         <div className="flex-1 overflow-hidden">
@@ -281,7 +283,7 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
                 className="hover:opacity-100 opacity-50 transition-opacity"
                 title="Copy Error ID"
               >
-                <span className="material-symbols-outlined text-[12px]">
+                <span className="material-symbols-outlined text-[12px]" aria-hidden="true">
                   {copied ? 'check' : 'content_copy'}
                 </span>
               </button>
@@ -302,7 +304,7 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
                 className="text-[10px] font-semibold uppercase tracking-wider opacity-60 hover:opacity-100 flex items-center gap-0.5"
               >
                 {showExpandedDetails ? 'Hide' : 'Show'} Technical Details
-                <span className="material-symbols-outlined text-[14px]">
+                <span className="material-symbols-outlined text-[14px]" aria-hidden="true">
                   {showExpandedDetails ? 'expand_less' : 'expand_more'}
                 </span>
               </button>
@@ -344,7 +346,9 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
                   aria-label={btn.label}
                 >
                   <span className="flex items-center gap-1">
-                    <span className="material-symbols-outlined text-[16px]">{btn.icon}</span>
+                    <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                      {btn.icon}
+                    </span>
                     {btn.label}
                   </span>
                 </button>
@@ -357,7 +361,9 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
           className={`flex-shrink-0 hover:opacity-70 transition-opacity p-0.5`}
           aria-label="Close error message"
         >
-          <span className="material-symbols-outlined text-[20px]">close</span>
+          <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+            close
+          </span>
         </button>
       </div>
     </div>

--- a/components/OfferComparison.tsx
+++ b/components/OfferComparison.tsx
@@ -76,7 +76,9 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
           <div className="bg-gradient-to-r from-primary-500 to-primary-600 rounded-xl p-6 text-white">
             <div className="flex items-start gap-4">
               <div className="bg-white/20 size-12 rounded-full flex items-center justify-center flex-shrink-0">
-                <span className="material-symbols-outlined text-2xl">star</span>
+                <span className="material-symbols-outlined text-2xl" aria-hidden="true">
+                  star
+                </span>
               </div>
               <div className="flex-1">
                 <h3 className="font-bold text-lg mb-1">Recommended Offer</h3>
@@ -344,13 +346,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.pros.length > 0 && (
                     <div className="bg-green-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-green-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_up</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_up
+                        </span>
                         Pros
                       </h5>
                       <ul className="space-y-1">
                         {score.pros.map((pro, idx) => (
                           <li key={idx} className="text-sm text-green-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               check
                             </span>
                             {pro}
@@ -363,13 +370,18 @@ export const OfferComparison: React.FC<OfferComparisonProps> = ({ comparison, on
                   {score.cons.length > 0 && (
                     <div className="bg-red-50 rounded-lg p-4">
                       <h5 className="text-sm font-bold text-red-900 mb-2 flex items-center gap-1">
-                        <span className="material-symbols-outlined text-[18px]">thumb_down</span>
+                        <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                          thumb_down
+                        </span>
                         Cons
                       </h5>
                       <ul className="space-y-1">
                         {score.cons.map((con, idx) => (
                           <li key={idx} className="text-sm text-red-800 flex items-start gap-1">
-                            <span className="material-symbols-outlined text-[14px] mt-0.5">
+                            <span
+                              className="material-symbols-outlined text-[14px] mt-0.5"
+                              aria-hidden="true"
+                            >
                               close
                             </span>
                             {con}

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    className="material-symbols-outlined text-[18px] font-bold"
+                    aria-hidden="true"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>

--- a/components/TemplateSelector.tsx
+++ b/components/TemplateSelector.tsx
@@ -157,7 +157,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                         : 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    <span className="material-symbols-outlined text-[24px]">
+                    <span className="material-symbols-outlined text-[24px]" aria-hidden="true">
                       {getTemplateIcon(template.category)}
                     </span>
                   </div>
@@ -274,13 +274,19 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                     <h4 className="text-sm font-bold text-slate-700 mb-2">Style & Category</h4>
                     <div className="space-y-1">
                       <div className="flex items-center gap-2">
-                        <span className="material-symbols-outlined text-[16px] text-slate-500">
+                        <span
+                          className="material-symbols-outlined text-[16px] text-slate-500"
+                          aria-hidden="true"
+                        >
                           style
                         </span>
                         <span className="text-sm text-slate-700 capitalize">{template.style}</span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <span className="material-symbols-outlined text-[16px] text-slate-500">
+                        <span
+                          className="material-symbols-outlined text-[16px] text-slate-500"
+                          aria-hidden="true"
+                        >
                           category
                         </span>
                         <span className="text-sm text-slate-700 capitalize">
@@ -298,7 +304,9 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                       onClick={() => onPreview(template.name)}
                       className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium"
                     >
-                      <span className="material-symbols-outlined text-[18px]">visibility</span>
+                      <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                        visibility
+                      </span>
                       Preview Template
                     </button>
                   </div>
@@ -312,7 +320,10 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
       {/* Empty State */}
       {filteredTemplates.length === 0 && (
         <div className="text-center py-8 bg-slate-50 rounded-lg">
-          <span className="material-symbols-outlined text-[48px] text-slate-400 mb-2">
+          <span
+            className="material-symbols-outlined text-[48px] text-slate-400 mb-2"
+            aria-hidden="true"
+          >
             folder_open
           </span>
           <p className="text-slate-600">No templates found in this category</p>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to `span` elements implementing `material-symbols-outlined` across multiple heavily-used components (`ResumeCard`, `TemplateSelector`, `OfferComparison`, `ErrorDisplay`, `ErrorBoundary`).

🎯 Why: The app uses Material Symbols via ligatures (e.g., `<span>star</span>`). Without `aria-hidden="true"`, screen readers will explicitly read out the literal text of the ligature, creating redundant or confusing auditory experiences for users (e.g., announcing "star Recommended Offer").

📸 Before/After: Visual presentation remains exactly the same.

♿ Accessibility: Significantly reduces screen reader noise and improves navigation clarity for users relying on assistive technology by hiding decorative and redundantly labeled icons from the accessibility tree.

---
*PR created automatically by Jules for task [515531455832812372](https://jules.google.com/task/515531455832812372) started by @anchapin*