### PR TITLE
🎨 Palette: [UX improvement] Fix and improve PasswordStrengthMeter a11y

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -18,3 +18,6 @@
 ## 2026-04-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations (like comment filter buttons) often lack necessary focus rings and active state announcements for screen readers. Using just active classes (e.g. `bg-white`) is not sufficient for keyboard navigation or screen reader context.
 **Action:** Always add explicit `focus-visible:ring` classes to ensure tab elements are navigable by keyboard. Use the `aria-pressed` or `aria-current` attributes to correctly announce the active tab to assistive technologies.
+## 2026-07-02 - Missing ARIA Live Regions on Dynamic Status Indicators
+**Learning:** Dynamic status indicators that update based on user input, like a password strength meter, often fail to announce their state changes to screen readers if they are not explicitly wrapped in an aria-live region. Additionally, visual elements like progress bars require proper ARIA roles (`role="progressbar"`) and attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`, `aria-label`) to provide semantic meaning and context.
+**Action:** Always wrap dynamic, text-based status indicators in an element with `aria-live="polite"` (or `assertive` if urgent). For visual bars representing a value, always add `role="progressbar"` and the associated `aria-value*` attributes.

--- a/components/PasswordStrengthMeter.tsx
+++ b/components/PasswordStrengthMeter.tsx
@@ -54,16 +54,21 @@ export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ pa
   if (!strength.label) return null;
 
   return (
-    <div className="mt-2">
+    <div className="mt-2" aria-live="polite">
       <div className="flex items-center justify-between mb-1">
         <span className="text-xs font-medium text-slate-600">Password Strength:</span>
-        <span className={'text-xs font-bold text-white px-2 py-0.5 rounded {strength.color}'}>
+        <span className={`text-xs font-bold text-white px-2 py-0.5 rounded ${strength.color}`}>
           {strength.label}
         </span>
       </div>
       <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
         <div
-          className={'h-full transition-all duration-300 {strength.color}'}
+          role="progressbar"
+          aria-valuenow={strength.score}
+          aria-valuemin={0}
+          aria-valuemax={5}
+          aria-label={`Password strength is ${strength.label}`}
+          className={`h-full transition-all duration-300 ${strength.color}`}
           style={{ width: `${(strength.score / 5) * 100}%` }}
         />
       </div>


### PR DESCRIPTION
💡 **What:** Fixed a JSX template literal syntax bug that was preventing the password strength meter from rendering its appropriate Tailwind color classes (e.g., `bg-red-500`, `bg-green-500`). Simultaneously, enhanced the component's accessibility by adding `aria-live="polite"` to the container and proper `role="progressbar"` semantics to the visual bar.

🎯 **Why:** The broken string interpolation meant the visual progress bar was practically invisible/unusable to sighted users since its background color wasn't being set. Furthermore, when the text *did* update, it was completely inaccessible to screen reader users because the updates weren't announced, and the bar itself lacked any semantic meaning.

📸 **Before/After:**
*Before:* 
- Strength bar missing color classes (e.g. `className="... {strength.color}"`).
- No screen reader announcements upon password strength change.
*After:* 
- Tailwind color classes dynamically applied.
- `aria-live` region appropriately announces status updates.

♿ **Accessibility:**
- Added `aria-live="polite"` to the parent container so strength changes (e.g., "Weak", "Strong") are dynamically announced to screen readers.
- Converted the visual `<div className="h-full...">` into a semantic `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and a descriptive `aria-label`.

---
*PR created automatically by Jules for task [15003269352772431014](https://jules.google.com/task/15003269352772431014) started by @anchapin*

## Summary by Sourcery

Fix the password strength meter styling bug and improve its accessibility semantics, while documenting the related accessibility guidance.

Bug Fixes:
- Correct password strength meter className interpolation so Tailwind color classes are applied to the label and bar.

Enhancements:
- Add aria-live region and progressbar semantics to the password strength meter so strength changes are announced and the bar has proper ARIA metadata.

Documentation:
- Extend the Palette accessibility notes with guidance on aria-live regions and progressbar ARIA attributes for dynamic status indicators.