### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons in Settings page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,16 +1,3 @@
-## 2025-05-24 - Consistent Copy Feedback
-
-**Learning:** The application had inconsistent feedback for copy actions. `ShareDialog` provided "Copied!" feedback, while `Settings` (API key copy) used a toast only. To improving perceived performance and assurance, immediate button state change is preferred over just toast notifications.
-**Action:** When implementing copy-to-clipboard functionality, always use the pattern: Change button text to "Copied!" and icon to "check" for 2 seconds, in addition to or instead of a toast.
-
-## 2025-05-24 - API Key Copy Button Accessibility
-
-**Learning:** The copy button for newly generated API keys lacked an `aria-label`, meaning screen readers would read it as a blank button after it was copied. The `ShareDialog` provided a better model for this interaction.
-**Action:** When implementing interactive buttons that change state (like copy buttons), always ensure the `aria-label` dynamically updates to reflect the new state (e.g. from "Copy API key" to "API key copied") to give screen reader users clear, immediate feedback of the action resolving.
-## 2026-03-08 - Added ARIA labels to icon-only buttons
-**Learning:** Found multiple instances where icon-only buttons lacked `aria-label` attributes and the inner Material Symbol `<span>` elements lacked `aria-hidden="true"`. This is a common pattern in the repository that reduces accessibility for screen reader users. Dynamic aria-labels (like "Expand details" vs "Collapse details") enhance context.
-**Action:** Always ensure icon-only buttons have descriptive `aria-label`s and hide decorative ligature icons with `aria-hidden="true"`.
-
-## 2026-03-09 - Ensure aria-hidden for ligature icons
-**Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
-**Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+## 2024-07-04 - Adding ARIA Labels to Icon-Only Buttons
+**Learning:** Found multiple instances in `pages/Settings.tsx` where icon-only buttons (like Notifications, API key visibility toggle, and Close modals) were missing `aria-label` attributes, which makes them inaccessible to screen readers.
+**Action:** When adding new icon-only interactive elements using Material Symbols, ensure they always have an `aria-label` attribute describing their action (e.g. `aria-label="Close"`).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,20 @@
+## 2025-05-24 - Consistent Copy Feedback
+
+**Learning:** The application had inconsistent feedback for copy actions. `ShareDialog` provided "Copied!" feedback, while `Settings` (API key copy) used a toast only. To improving perceived performance and assurance, immediate button state change is preferred over just toast notifications.
+**Action:** When implementing copy-to-clipboard functionality, always use the pattern: Change button text to "Copied!" and icon to "check" for 2 seconds, in addition to or instead of a toast.
+
+## 2025-05-24 - API Key Copy Button Accessibility
+
+**Learning:** The copy button for newly generated API keys lacked an `aria-label`, meaning screen readers would read it as a blank button after it was copied. The `ShareDialog` provided a better model for this interaction.
+**Action:** When implementing interactive buttons that change state (like copy buttons), always ensure the `aria-label` dynamically updates to reflect the new state (e.g. from "Copy API key" to "API key copied") to give screen reader users clear, immediate feedback of the action resolving.
+## 2026-03-08 - Added ARIA labels to icon-only buttons
+**Learning:** Found multiple instances where icon-only buttons lacked `aria-label` attributes and the inner Material Symbol `<span>` elements lacked `aria-hidden="true"`. This is a common pattern in the repository that reduces accessibility for screen reader users. Dynamic aria-labels (like "Expand details" vs "Collapse details") enhance context.
+**Action:** Always ensure icon-only buttons have descriptive `aria-label`s and hide decorative ligature icons with `aria-hidden="true"`.
+
+## 2026-03-09 - Ensure aria-hidden for ligature icons
+**Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
+**Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
 ## 2024-07-04 - Adding ARIA Labels to Icon-Only Buttons
 **Learning:** Found multiple instances in `pages/Settings.tsx` where icon-only buttons (like Notifications, API key visibility toggle, and Close modals) were missing `aria-label` attributes, which makes them inaccessible to screen readers.
 **Action:** When adding new icon-only interactive elements using Material Symbols, ensure they always have an `aria-label` attribute describing their action (e.g. `aria-label="Close"`).

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -346,7 +346,10 @@ const Settings: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <h2 className="text-slate-800 font-bold text-xl">Settings</h2>
         <div className="flex items-center gap-4">
-          <button className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative">
+          <button
+            className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative"
+            aria-label="Notifications"
+          >
             <span className="material-symbols-outlined">notifications</span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </button>
@@ -397,6 +400,7 @@ const Settings: React.FC = () => {
                   type="button"
                   onClick={() => setShowApiKey(!showApiKey)}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                  aria-label="Toggle API key visibility"
                 >
                   <span className="material-symbols-outlined text-[20px]">
                     {showApiKey ? 'visibility_off' : 'visibility'}
@@ -878,6 +882,7 @@ const Settings: React.FC = () => {
               <button
                 onClick={handleCloseCreateModal}
                 className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Close"
               >
                 <span className="material-symbols-outlined">close</span>
               </button>
@@ -1054,6 +1059,7 @@ const Settings: React.FC = () => {
                   setEditingWebhook(undefined);
                 }}
                 className="p-2 text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Close"
               >
                 <span className="material-symbols-outlined">close</span>
               </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to several icon-only buttons in the `Settings.tsx` page (Notifications, Toggle API key visibility, and Close buttons for both the Create API Key and Create Webhook modals).
🎯 Why: Icon-only buttons without an accessible name are completely opaque to screen reader users, violating accessibility guidelines.
📸 Before/After: Visual appearance is unchanged.
♿ Accessibility: Improves accessibility for screen reader users by providing descriptive labels for these interactive elements.

---
*PR created automatically by Jules for task [7305324270212121467](https://jules.google.com/task/7305324270212121467) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only controls in the Settings page by adding ARIA labels and updating palette guidance.

Enhancements:
- Add descriptive aria-label attributes to icon-only buttons on the Settings page, including notifications, API key visibility toggle, and modal close actions.

Documentation:
- Update the Palette guidance document to capture the accessibility pattern for ARIA labels on icon-only Material Symbols buttons in Settings.