### PR TITLE
🎨 Palette: Fix password strength color interpolation

### DIFF
--- a/components/PasswordStrengthMeter.tsx
+++ b/components/PasswordStrengthMeter.tsx
@@ -57,13 +57,13 @@ export const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({ pa
     <div className="mt-2">
       <div className="flex items-center justify-between mb-1">
         <span className="text-xs font-medium text-slate-600">Password Strength:</span>
-        <span className={'text-xs font-bold text-white px-2 py-0.5 rounded {strength.color}'}>
+        <span className={`text-xs font-bold text-white px-2 py-0.5 rounded ${strength.color}`}>
           {strength.label}
         </span>
       </div>
       <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
         <div
-          className={'h-full transition-all duration-300 {strength.color}'}
+          className={`h-full transition-all duration-300 ${strength.color}`}
           style={{ width: `${(strength.score / 5) * 100}%` }}
         />
       </div>


### PR DESCRIPTION
💡 What: Replaced single quotes with backticks to correctly interpolate the dynamic color class in the `PasswordStrengthMeter` component.
🎯 Why: The component was previously passing a literal string `{strength.color}` to the CSS class instead of the actual color value (e.g., `bg-green-500`), meaning the text badge and progress bar were not receiving their dynamic strength-based colors.
📸 Before/After: Verified with Playwright screenshots. The password strength text badge and progress bar now correctly change color based on the strength of the input password.
♿ Accessibility: Provides immediate, correctly-colored visual feedback to users regarding their password strength, aiding in the creation of secure passwords.

---
*PR created automatically by Jules for task [6154705961151350261](https://jules.google.com/task/6154705961151350261) started by @anchapin*

## Summary by Sourcery

Bug Fixes:
- Fix password strength badge and progress bar using a literal strength color string instead of the interpolated Tailwind class.