### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 query in list_teams

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,8 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+
+## 2024-07-11 - SQLAlchemy N+1 Query Optimization and Linting
+
+**Learning:** When resolving flake8 `E712` (comparison to False) linting errors in SQLAlchemy queries (e.g., `resume-api/`), changing `== False` to `is False` breaks the query builder because SQLAlchemy requires the `==` operator to overload the boolean expression for SQL generation (`ColumnElement` takes no arguments if you try to evaluate it with `is`).
+**Action:** Do not change `== False` to `is False` in SQLAlchemy where clauses. Instead, append `# noqa: E712` to the line to ensure backend queries function correctly while satisfying the linter.

--- a/resume-api/api/team_routes.py
+++ b/resume-api/api/team_routes.py
@@ -184,18 +184,34 @@ async def list_teams(
         teams = result.scalars().all()
 
         team_responses = []
-        for team in teams:
-            member_count_stmt = select(func.count(TeamMember.id)).where(
-                TeamMember.team_id == team.id
-            )
-            result = await db.execute(member_count_stmt)
-            member_count = result.scalar() or 0
 
-            resume_count_stmt = select(func.count(TeamResume.id)).where(
-                TeamResume.team_id == team.id
+        if teams:
+            team_ids = [team.id for team in teams]
+
+            # Fetch member counts in a single query
+            member_counts_stmt = (
+                select(TeamMember.team_id, func.count(TeamMember.id))
+                .where(TeamMember.team_id.in_(team_ids))
+                .group_by(TeamMember.team_id)
             )
-            result = await db.execute(resume_count_stmt)
-            resume_count = result.scalar() or 0
+            member_counts_result = await db.execute(member_counts_stmt)
+            member_counts = {row[0]: row[1] for row in member_counts_result.all()}
+
+            # Fetch resume counts in a single query
+            resume_counts_stmt = (
+                select(TeamResume.team_id, func.count(TeamResume.id))
+                .where(TeamResume.team_id.in_(team_ids))
+                .group_by(TeamResume.team_id)
+            )
+            resume_counts_result = await db.execute(resume_counts_stmt)
+            resume_counts = {row[0]: row[1] for row in resume_counts_result.all()}
+        else:
+            member_counts = {}
+            resume_counts = {}
+
+        for team in teams:
+            member_count = member_counts.get(team.id, 0)
+            resume_count = resume_counts.get(team.id, 0)
 
             team_responses.append(
                 TeamResponse(
@@ -752,7 +768,6 @@ async def get_team_member(
     Rate limit: 30 requests per minute per API key.
     """
     try:
-        user_id = auth.user_id if hasattr(auth, "user_id") else 1
 
         team_stmt = select(Team).where(Team.id == team_id)
         result = await db.execute(team_stmt)
@@ -1516,9 +1531,7 @@ async def delete_resume_comment(
     try:
         user_id = auth.user_id if hasattr(auth, "user_id") else 1
 
-        stmt = select(Comment).where(
-            and_(Comment.id == comment_id, Comment.resume_id == resume_id)
-        )
+        stmt = select(Comment).where(and_(Comment.id == comment_id, Comment.resume_id == resume_id))
         result = await db.execute(stmt)
         comment = result.scalar_one_or_none()
 


### PR DESCRIPTION
💡 **What:** 
Optimized the `list_teams` (`get_teams`) endpoint in `resume-api/api/team_routes.py` to prevent an N+1 query problem. Instead of executing two `COUNT` queries per team inside a loop, it now executes two batched queries outside the loop using `IN` and `GROUP BY` to aggregate the member and resume counts for all fetched teams at once.

🎯 **Why:** 
The previous implementation caused an N+1 query bottleneck. Retrieving a list of 10 teams would result in 1 query for the teams, plus 10 queries for member counts and 10 queries for resume counts (21 queries total). With this change, the endpoint now reliably executes only 3 queries total regardless of the number of teams returned.

📊 **Impact:** 
Significantly reduces database latency and overhead on the team listing endpoint. Queries scale at O(1) instead of O(N) relative to the number of teams a user belongs to. 

🔬 **Measurement:** 
1. `pytest tests/test_teams.py` was used to ensure no regressions were introduced to team fetching.
2. The global `pnpm test run` was run to ensure frontend regression safety.
3. Linting was satisfied (after learning that SQLAlchemy requires `== False` instead of `is False`).

---
*PR created automatically by Jules for task [17021107922835684259](https://jules.google.com/task/17021107922835684259) started by @anchapin*