### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect } from 'react';
 import { ErrorContext, ErrorType } from '../utils/errorHandler';
 import { getErrorMessageByType, getErrorSuggestion } from '../utils/errorMessages';
@@ -280,6 +279,7 @@ ${error.context ? `\nContext: ${JSON.stringify(error.context, null, 2)}` : ''}
                 onClick={copyErrorId}
                 className="hover:opacity-100 opacity-50 transition-opacity"
                 title="Copy Error ID"
+                aria-label="Copy Error ID"
               >
                 <span className="material-symbols-outlined text-[12px]">
                   {copied ? 'check' : 'content_copy'}

--- a/components/GitHubSyncDialog.tsx
+++ b/components/GitHubSyncDialog.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { secureApiCall, getAuthToken } from '../utils/security';
@@ -127,7 +126,7 @@ async function fetchGitHubRepositories(): Promise<GitHubRepository[]> {
  * Allows users to sync their GitHub repositories to their resume.
  * Checks OAuth connection status and prompts connection if needed.
  */
- 
+
 export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
   isOpen,
   onClose,
@@ -294,6 +293,7 @@ export const GitHubSyncDialog: React.FC<GitHubSyncDialogProps> = ({
             onClick={onClose}
             className="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
             disabled={isSyncing || isConnecting}
+            aria-label="Close dialog"
           >
             <span className="material-symbols-outlined">close</span>
           </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to icon-only buttons in `ErrorDisplay` and `GitHubSyncDialog` components.
🎯 Why: To improve accessibility for screen readers, allowing users to understand the action associated with icon-only buttons.
📸 Before/After: Not applicable (invisible UX improvement).
♿ Accessibility: Improved screen reader navigation and context for the copy error ID and close dialog buttons.

---
*PR created automatically by Jules for task [5432015796280765207](https://jules.google.com/task/5432015796280765207) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only controls in GitHub sync and error display dialogs by adding appropriate ARIA labels.

New Features:
- Provide an ARIA label for the close button in the GitHub sync dialog.
- Provide an ARIA label for the copy error ID button in the error display component.

Enhancements:
- Minor formatting cleanup in component files.