### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-27 - Regex Cross-Matching Risk in Tag Sanitization
 **Learning:** Consolidating start and end HTML tag patterns into a single regex with a shared group (like `<(?:iframe|form|input)[^>]*>.*?</(?:iframe|form|input)>`) is a critical security and functionality bug because it allows cross-matching (e.g., `<input>...</form>`), leading to data loss.
 **Action:** When stripping multiple different HTML tags via regex, always iterate over a list of pre-compiled individual tag patterns (e.g., one for `iframe`, one for `form`) rather than merging them into a single cross-matching OR pattern.
+
+## 2026-07-12 - Optimize keyword extraction using collections.Counter
+**Learning:** Manual dictionary-based word frequency counting (incrementing keys and sorting `.items()`) is slower than `collections.Counter`, which is implemented in C and optimized for this exact use case.
+**Action:** Always prefer `collections.Counter` along with a generator expression or list comprehension for frequency counting of elements in sequences, especially for strings and text processing.

--- a/resume-api/lib/cli/tailorer.py
+++ b/resume-api/lib/cli/tailorer.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from typing import Dict, Any, List, Optional
 
 try:
@@ -289,11 +290,10 @@ Return ONLY valid JSON, nothing else."""
             "most",
         }
         keywords = [w for w in words if len(w) > 2 and w not in stop_words]
-        word_freq: Dict[str, int] = {}
-        for word in keywords:
-            word_freq[word] = word_freq.get(word, 0) + 1
-        sorted_kw = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)
-        return [word for word, _ in sorted_kw[:20]]
+
+        # ⚡ Bolt Optimization: Use collections.Counter for faster frequency counting
+        # Filter and count using the C-optimized Counter
+        return [word for word, _ in Counter(keywords).most_common(20)]
 
     def suggest_improvements(self, resume_data: Dict[str, Any], job_description: str) -> List[str]:
         """


### PR DESCRIPTION
💡 What: Replaced a manual dictionary-based frequency counter and full array sort with `collections.Counter` in the `_extract_keywords_fallback` method of `ResumeTailorer`.

🎯 Why: The previous method iterated over words to build a dictionary, then used Python's `sorted()` to sort all items before slicing the top 20. `collections.Counter(keywords).most_common(20)` accomplishes the same logic entirely in a C-optimized implementation, using a heap under the hood to find the top elements without performing a full sort of all unique words, significantly reducing execution overhead.

📊 Impact: Reduces computational overhead for keyword extraction by utilizing Python's C-level standard library structures, which is especially noticeable when parsing large job descriptions or processing multiple documents concurrently.

🔬 Measurement: Verify using `cd resume-api && export OPENAI_API_KEY="test-key" && export PYTHONPATH=$(pwd) && export JWT_SECRET="12345678901234567890123456789012" && python -m pytest test_tailorer.py::TestKeywordExtraction`. The test suite should pass exactly as before.

---
*PR created automatically by Jules for task [6362961167813895053](https://jules.google.com/task/6362961167813895053) started by @anchapin*