### PR TITLE
🛡️ Sentinel: [HIGH] Fix weak password hashing for resume shares

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,9 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-05-18 - [Weak Password Hashing via hashlib.sha256]
+
+**Vulnerability:** The application was using Python's built-in `hashlib.sha256()` directly on plaintext user passwords (specifically, for the resume sharing password feature). This creates an unsalted, fast hash which is highly vulnerable to dictionary attacks, rainbow tables, and brute force attacks.
+**Learning:** Whenever introducing new features that involve authentication or password checking (like share tokens or passcodes), developers often fall back to standard library hashing if they overlook centralized security modules.
+**Prevention:** Always use centralized, verified security utilities (`hash_password`, `verify_password` powered by bcrypt/argon2) for any credential handling. When migrating legacy hashes to modern ones, always verify the hash prefix (e.g., `$2b$`) to safely fallback and avoid locking out existing data.

--- a/resume-api/api/advanced_routes.py
+++ b/resume-api/api/advanced_routes.py
@@ -23,6 +23,8 @@ from sqlalchemy import select, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from config.security import hash_password, verify_password
+
 from .models import (
     # Request models
     CreateResumeRequest,
@@ -824,9 +826,7 @@ async def share_resume(
 
         # Hash password if provided
         if request.password:
-            import hashlib
-
-            share.share_password_hash = hashlib.sha256(request.password.encode()).hexdigest()
+            share.share_password_hash = hash_password(request.password)
 
         db.add(share)
 
@@ -907,10 +907,7 @@ async def access_shared_resume(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Password required",
                 )
-            import hashlib
-
-            password_hash = hashlib.sha256(password.encode()).hexdigest()
-            if password_hash != share.share_password_hash:
+            if not verify_password(password, share.share_password_hash):
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid password",
@@ -1108,7 +1105,9 @@ async def batch_create_resumes(
 
             # Add tags
             if resume_request.tags:
-                existing_tags_result = await db.execute(select(Tag).where(Tag.name.in_(resume_request.tags)))
+                existing_tags_result = await db.execute(
+                    select(Tag).where(Tag.name.in_(resume_request.tags))
+                )
                 existing_tags_dict = {t.name: t for t in existing_tags_result.scalars().all()}
                 for tag_name in resume_request.tags:
                     existing_tag = existing_tags_dict.get(tag_name)
@@ -1230,7 +1229,9 @@ async def batch_update_resumes(
             # Update tags if provided
             if update_request.tags is not None:
                 resume.tags.clear()
-                existing_tags_result = await db.execute(select(Tag).where(Tag.name.in_(update_request.tags)))
+                existing_tags_result = await db.execute(
+                    select(Tag).where(Tag.name.in_(update_request.tags))
+                )
                 existing_tags_dict = {t.name: t for t in existing_tags_result.scalars().all()}
                 for tag_name in update_request.tags:
                     existing_tag = existing_tags_dict.get(tag_name)

--- a/resume-api/config/security.py
+++ b/resume-api/config/security.py
@@ -37,6 +37,7 @@ def hash_password(password: str) -> str:
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
     Verify a password against its hash.
+    Includes fallback for backward compatibility with legacy unsalted SHA-256 hashes.
 
     Args:
         plain_password: Plain text password to verify
@@ -45,6 +46,10 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     Returns:
         True if password matches, False otherwise
     """
+    if not hashed_password.startswith("$"):
+        from passlib.hash import hex_sha256
+
+        return hex_sha256.verify(plain_password, hashed_password)
     return pwd_context.verify(plain_password, hashed_password)
 
 


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
The application was using Python's built-in `hashlib.sha256()` directly on plaintext user passwords (specifically, for the resume sharing password feature). This creates an unsalted, fast hash which is highly vulnerable to dictionary attacks, rainbow tables, and brute force attacks.

🎯 Impact:
If the database is compromised, attackers could trivially and rapidly crack the unsalted SHA-256 hashes for shared resumes, leading to unauthorized access to potentially sensitive user information.

🔧 Fix:
- Replaced unsalted `hashlib.sha256` with bcrypt-based `hash_password` in `resume-api/api/advanced_routes.py` for the resume share password feature.
- Replaced manual SHA-256 equality checks with `verify_password`.
- Updated `verify_password` in `resume-api/config/security.py` to maintain backward compatibility for legacy unsalted SHA-256 hashes by checking for the bcrypt `$` prefix and safely falling back using `passlib.hash.hex_sha256`.

✅ Verification:
- All targeted share tests continue to pass (`pytest resume-api/tests/ -k share`).
- The global test suite (`pnpm test run`) completes successfully with zero regressions.
- Legacy hashes are safely handled via `passlib` without introducing any new CodeQL flags.

---
*PR created automatically by Jules for task [11508814439523972727](https://jules.google.com/task/11508814439523972727) started by @anchapin*