### PR TITLE
🎨 Palette: Add aria-labels and aria-hidden to icon-only buttons

### DIFF
--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -125,9 +125,9 @@ const Dashboard: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <div className="flex items-center gap-6">
           <h2 className="text-slate-800 font-bold text-xl">Job Search Overview</h2>
-          <Button 
-            variant="outline" 
-            size="sm" 
+          <Button
+            variant="outline"
+            size="sm"
             className="flex items-center gap-2"
             onClick={() => setShowImportDialog(true)}
           >
@@ -136,8 +136,10 @@ const Dashboard: React.FC = () => {
           </Button>
         </div>
         <div className="flex items-center gap-4">
-          <Button variant="ghost" className="p-2 relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <Button variant="ghost" className="p-2 relative" aria-label="Notifications">
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </Button>
           <div

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -1,4 +1,3 @@
- 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTheme } from '../hooks/useTheme';
 import { toast } from 'react-toastify';
@@ -346,8 +345,13 @@ const Settings: React.FC = () => {
       <header className="h-16 flex items-center justify-between px-8 bg-white/80 backdrop-blur-sm sticky top-0 z-10 border-b border-slate-200">
         <h2 className="text-slate-800 font-bold text-xl">Settings</h2>
         <div className="flex items-center gap-4">
-          <button className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative">
-            <span className="material-symbols-outlined">notifications</span>
+          <button
+            className="p-2 text-slate-400 hover:text-slate-600 transition-colors relative"
+            aria-label="Notifications"
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              notifications
+            </span>
             <div className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white"></div>
           </button>
           <div


### PR DESCRIPTION
💡 What: Added `aria-label="Notifications"` to the icon-only notification buttons and `aria-hidden="true"` to their inner material-icon spans in `pages/Dashboard.tsx` and `pages/Settings.tsx`.

🎯 Why: To ensure screen readers announce the button's purpose correctly rather than attempting to read the literal word "notifications" as generic text or reading nothing if not well-supported.

📸 Before/After:
Before:
`<button className="..."><span className="...">notifications</span>...</button>`

After:
`<button className="..." aria-label="Notifications"><span className="..." aria-hidden="true">notifications</span>...</button>`

♿ Accessibility: Significantly improves screen reader accessibility by providing proper descriptive labels for interactive icon-only elements while hiding decorative spans.

---
*PR created automatically by Jules for task [14705988365012973792](https://jules.google.com/task/14705988365012973792) started by @anchapin*

## Summary by Sourcery

Improve accessibility of icon-only notification buttons across dashboard and settings pages.

Enhancements:
- Add descriptive aria-labels to notification icon buttons on Dashboard and Settings pages for screen reader support.
- Mark inner notification icon spans as aria-hidden to prevent redundant or confusing announcements by assistive technologies.