### PR TITLE
🎨 Palette: Improve accessibility of SkillsSection interactive elements

### DIFF
--- a/components/editor/SkillsSection.tsx
+++ b/components/editor/SkillsSection.tsx
@@ -16,10 +16,12 @@ export const SkillsSection = React.memo<SkillsSectionProps>(
           <div className="flex items-center gap-2">
             <button
               onClick={onShowCommentPanel}
-              className="flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-primary-600 transition-colors"
+              className="flex items-center gap-1 text-sm font-bold text-slate-500 hover:text-primary-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-md"
               title="Add comment to this section"
             >
-              <span className="material-symbols-outlined text-[18px]">chat_bubble_outline</span>
+              <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                chat_bubble_outline
+              </span>
               <span>Add Comment</span>
             </button>
             <span className="text-sm font-medium text-slate-500">
@@ -40,9 +42,13 @@ export const SkillsSection = React.memo<SkillsSectionProps>(
                   {skill}
                   <button
                     onClick={() => onRemoveSkill(skill)}
-                    className="hover:text-primary-900 ml-1"
+                    className="hover:text-primary-900 ml-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-md"
+                    aria-label={`Remove skill ${skill}`}
+                    title={`Remove skill ${skill}`}
                   >
-                    <span className="material-symbols-outlined text-[16px]">close</span>
+                    <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                      close
+                    </span>
                   </button>
                 </span>
               ))}

--- a/tests/components/editor/SkillsSection.test.tsx
+++ b/tests/components/editor/SkillsSection.test.tsx
@@ -84,7 +84,7 @@ describe('SkillsSection', () => {
       render(<SkillsSection {...defaultProps} onRemoveSkill={onRemoveSkill} />);
 
       // Find all buttons with name "close" - these are the skill remove buttons
-      const closeButtons = screen.getAllByRole('button', { name: /close/i });
+      const closeButtons = screen.getAllByRole('button', { name: /Remove.*skill/i });
       // The first close button should be for the first skill (React)
       await user.click(closeButtons[0]);
 


### PR DESCRIPTION
### 💡 What:
Improved the accessibility and keyboard navigation of the `SkillsSection` component.
- Added `aria-hidden="true"` to the inner `<span>` elements containing Material Symbol ligature text (e.g., "chat_bubble_outline", "close") so screen readers don't read them aloud.
- Added dynamic `aria-label` and `title` attributes (e.g., "Remove skill React") to the icon-only "Remove" buttons.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-md` classes to both the "Add Comment" and "Remove" buttons for clear, consistent visual feedback during keyboard navigation.
- Updated the associated test suite to query the remove buttons by their new accessible names.

### 🎯 Why:
To ensure the application is usable for everyone. Without `aria-hidden`, screen readers will read the literal text of the ligature (e.g., reading "close" when the user lands on a button). Without an `aria-label`, an icon-only button lacks context (e.g. "close" what?). Without focus styles, keyboard users cannot tell which element they are interacting with.

### 📸 Before/After:
*Visual change is limited to keyboard focus states (a primary-colored ring appears when tabbing to the buttons).*
*Semantic change removes confusing screen reader announcements and adds context.*

### ♿ Accessibility:
- Resolves missing context on icon-only buttons for screen reader users.
- Resolves ligature text being read aloud.
- Resolves missing visible focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [835282439524048878](https://jules.google.com/task/835282439524048878) started by @anchapin*

## Summary by Sourcery

Improve accessibility and keyboard focus handling for the SkillsSection interactive controls.

Enhancements:
- Add focus-visible ring and outline reset to the SkillsSection comment and remove skill buttons for clearer keyboard focus indication.
- Mark icon ligature spans in SkillsSection as aria-hidden to prevent screen readers from announcing decorative text.
- Provide dynamic aria-label and title text on skill removal buttons to convey their purpose to assistive technologies.

Tests:
- Update SkillsSection tests to query remove buttons using their new accessible names instead of icon text.