### PR TITLE
🎨 Palette: Add aria-hidden to ligature icons in ResumeCard

### DIFF
--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[16px]">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    aria-hidden="true"
+                    className="material-symbols-outlined text-[18px] font-bold"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span aria-hidden="true" className="material-symbols-outlined text-[18px]">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span aria-hidden="true" className="material-symbols-outlined text-[16px]">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to all `<span>` elements using the `material-symbols-outlined` class in `components/ResumeCard.tsx`.

🎯 Why: Material Symbols use text ligatures (e.g., `<span ...>share</span>`), which causes screen readers to redundantly or confusingly read the visual text out loud (e.g., "share", "update", "delete"). Hiding these from screen readers improves the experience since surrounding accessible elements (like buttons with `aria-label`s) already provide the necessary context.

📸 Before/After: Visuals remain unchanged.
- Before: Screen reader announces "share Share Resume".
- After: Screen reader correctly announces "Share Resume".

♿ Accessibility: Prevents screen readers from announcing non-semantic icon ligature text, reducing cognitive load and redundancy.

---
*PR created automatically by Jules for task [13313084464865663416](https://jules.google.com/task/13313084464865663416) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Add aria-hidden="true" to Material Symbols icon spans in ResumeCard to prevent redundant screen reader announcements.