### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS Bypass via Nested Tags in sanitize_html

### DIFF
--- a/resume-api/api/models.py
+++ b/resume-api/api/models.py
@@ -46,17 +46,26 @@ def sanitize_html(text: Optional[str]) -> Optional[str]:
     if not text:
         return None
 
-    # Remove script tags and content
-    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.IGNORECASE | re.DOTALL)
+    while True:
+        original = text
+        # Remove script tags and content
+        text = re.sub(
+            r"<script[^>]*>.*?</script(?:\s[^>]*>|>)", "", text, flags=re.IGNORECASE | re.DOTALL
+        )
 
-    # Remove other dangerous tags
-    dangerous_tags = ["iframe", "object", "embed", "form", "input", "button"]
-    for tag in dangerous_tags:
-        text = re.sub(f"<{tag}[^>]*>.*?</{tag}>", "", text, flags=re.IGNORECASE | re.DOTALL)
-        text = re.sub(f"<{tag}[^>]*/?>", "", text, flags=re.IGNORECASE)
+        # Remove other dangerous tags
+        dangerous_tags = ["iframe", "object", "embed", "form", "input", "button"]
+        for tag in dangerous_tags:
+            text = re.sub(
+                rf"<{tag}[^>]*>.*?</{tag}(?:\s[^>]*>|>)", "", text, flags=re.IGNORECASE | re.DOTALL
+            )
+            text = re.sub(rf"<{tag}[^>]*/?>", "", text, flags=re.IGNORECASE)
+
+        if text == original:
+            break
 
     # Remove event handlers (onclick, onerror, etc.)
-    text = re.sub(r'on\w+\s*=\s*["\'][^"\']*["\']', "", text, flags=re.IGNORECASE)
+    text = re.sub(r'on\w+\s*=\s*(?:["\'][^"\']*["\']|[^>\s]+)', "", text, flags=re.IGNORECASE)
 
     # Remove javascript: and data: URLs
     text = re.sub(r"javascript\s*:", "", text, flags=re.IGNORECASE)
@@ -2154,5 +2163,6 @@ class QueueStatsResponse(BaseModel):
                 "worker_running": True,
             }
         }
+
 
 ResumeRequest.model_rebuild()

--- a/resume-api/lib/utils/validators.py
+++ b/resume-api/lib/utils/validators.py
@@ -247,10 +247,12 @@ def validate_list_length(
 # Pre-compiled regex patterns for HTML sanitization
 # Pre-compiling these patterns provides a significant speedup (~3x)
 # by avoiding redundant regex compilation and evaluation in a nested loop.
-_SCRIPT_PATTERN = re.compile(r"<script[^>]*>.*?</script\s*[^>]*>", flags=re.IGNORECASE | re.DOTALL)
+_SCRIPT_PATTERN = re.compile(
+    r"<script[^>]*>.*?</script(?:\s[^>]*>|>)", flags=re.IGNORECASE | re.DOTALL
+)
 _DANGEROUS_TAGS_PATTERNS = [
     (
-        re.compile(rf"<{tag}[^>]*>.*?</{tag}>", flags=re.IGNORECASE | re.DOTALL),
+        re.compile(rf"<{tag}[^>]*>.*?</{tag}(?:\s[^>]*>|>)", flags=re.IGNORECASE | re.DOTALL),
         re.compile(rf"<{tag}[^>]*/?>", flags=re.IGNORECASE),
     )
     for tag in ["iframe", "object", "embed", "form", "input", "button"]
@@ -279,13 +281,18 @@ def sanitize_html(text: Optional[str]) -> Optional[str]:
     if not text:
         return None
 
-    # Remove script tags and content
-    text = _SCRIPT_PATTERN.sub("", text)
+    while True:
+        original = text
+        # Remove script tags and content
+        text = _SCRIPT_PATTERN.sub("", text)
 
-    # Remove other dangerous tags
-    for tag_content_pattern, tag_inline_pattern in _DANGEROUS_TAGS_PATTERNS:
-        text = tag_content_pattern.sub("", text)
-        text = tag_inline_pattern.sub("", text)
+        # Remove other dangerous tags
+        for tag_content_pattern, tag_inline_pattern in _DANGEROUS_TAGS_PATTERNS:
+            text = tag_content_pattern.sub("", text)
+            text = tag_inline_pattern.sub("", text)
+
+        if text == original:
+            break
 
     # Remove event handlers (handles both quoted and unquoted attributes)
     text = _ON_EVENT_PATTERN.sub("", text)


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The `sanitize_html` functions in `resume-api/api/models.py` and `resume-api/lib/utils/validators.py` suffered from multiple XSS bypasses:
1.  **Nested tag bypass:** Removing a tag once allows a nested payload like `<scr<script>ipt>alert(1)</script>` to become `<script>alert(1)</script>`.
2.  **Closing tag whitespace bypass:** The regex `<script[^>]*>.*?</script>` does not match `</script >` or `</script \n>`, which browsers will execute.

🎯 Impact: An attacker could bypass HTML sanitization and execute malicious JavaScript when the content is rendered in a browser, leading to session hijacking, defacement, or other Cross-Site Scripting (XSS) consequences.

🔧 Fix:
1.  Wrapped the tag removal operations inside a `while True` loop that continues until the string stops shrinking. This reliably eliminates nested tag bypasses.
2.  Updated the regex for closing tags (e.g., `</script(?:\s[^>]*>|>)`) to securely handle trailing whitespace or malformed attributes inside the closing tag.

✅ Verification: Verified locally by running the test suite via `pytest resume-api/tests/test_validators.py` and checking explicit XSS payloads. Run `pnpm test run` and `pnpm lint` to ensure global pipeline passes.

---
*PR created automatically by Jules for task [7978133591065295788](https://jules.google.com/task/7978133591065295788) started by @anchapin*

## Summary by Sourcery

Harden HTML sanitization to close XSS bypasses in both the API models and shared validators.

Bug Fixes:
- Fix XSS bypasses in sanitize_html caused by nested dangerous tags not being fully removed in a single pass.
- Fix failure to strip script and other dangerous tags when their closing tags contain trailing whitespace or malformed attributes.
- Fix omission of unquoted JavaScript event handler attributes from HTML sanitization.

Enhancements:
- Align and centralize stronger HTML sanitization behavior between the model-level and shared validator implementations.