### PR TITLE
🎨 Palette: Add aria-hidden to ligature icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2026-03-09 - Ensure aria-hidden for ligature icons
 **Learning:** Adding `aria-label`s to buttons is critical, but when the button uses an icon font like Material Symbols that relies on text ligatures (e.g., `close`, `history`, `edit`), screen readers will read the ligature text aloud. This creates a confusing experience (e.g. reading "Close close" or just "Close" when it should be "Close form").
 **Action:** When adding `aria-label` to an icon-only button that uses ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`.
+
+## 2026-03-09 - Added aria-hidden to ligature icons in ResumeCard
+**Learning:** Found multiple instances where icon-only buttons or icons with adjacent text used Material Symbols ligatures without `aria-hidden="true"`. This is a common pattern in the repository that reduces accessibility for screen reader users by causing redundant text readouts (e.g., "Edit Resume, edit, button").
+**Action:** When adding or updating ligature icons, always ensure the inner `<span>` element containing the ligature text has `aria-hidden="true"`, particularly when the parent element has an `aria-label` or contains visible text.

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,7 +73,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]">update</span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+                  update
+                </span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -88,7 +90,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">share</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                share
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -97,7 +101,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">edit</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                edit
+              </span>
             </Button>
             <Button
               variant="ghost"
@@ -106,7 +112,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]">content_copy</span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                content_copy
+              </span>
             </Button>
 
             {isDeleting ? (
@@ -124,7 +132,12 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px] font-bold">check</span>
+                  <span
+                    className="material-symbols-outlined text-[18px] font-bold"
+                    aria-hidden="true"
+                  >
+                    check
+                  </span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -138,7 +151,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]">close</span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                    close
+                  </span>
                 </Button>
               </div>
             ) : (
@@ -154,7 +169,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]">delete</span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
+                  delete
+                </span>
               </Button>
             )}
           </div>
@@ -182,7 +199,9 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]">history</span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
+              history
+            </span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>

--- a/components/ResumeCard.tsx
+++ b/components/ResumeCard.tsx
@@ -73,9 +73,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
             <div className="flex-1">
               <h3 className="font-bold text-slate-900 text-lg mb-1">{resume.title}</h3>
               <div className="flex items-center gap-2 text-sm text-slate-500">
-                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
-                  update
-                </span>
+                <span className="material-symbols-outlined text-[16px]" aria-hidden="true">update</span>
                 <span>Last updated {formatDate(resume.updatedAt)}</span>
               </div>
             </div>
@@ -90,9 +88,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Share Resume"
               aria-label="Share Resume"
             >
-              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
-                share
-              </span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">share</span>
             </Button>
             <Button
               variant="ghost"
@@ -101,9 +97,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Edit Resume"
               aria-label="Edit Resume"
             >
-              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
-                edit
-              </span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">edit</span>
             </Button>
             <Button
               variant="ghost"
@@ -112,9 +106,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
               title="Duplicate Resume"
               aria-label="Duplicate Resume"
             >
-              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
-                content_copy
-              </span>
+              <span className="material-symbols-outlined text-[20px]" aria-hidden="true">content_copy</span>
             </Button>
 
             {isDeleting ? (
@@ -132,12 +124,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Confirm delete"
                   title="Confirm Delete"
                 >
-                  <span
-                    className="material-symbols-outlined text-[18px] font-bold"
-                    aria-hidden="true"
-                  >
-                    check
-                  </span>
+                  <span className="material-symbols-outlined text-[18px] font-bold" aria-hidden="true">check</span>
                 </Button>
                 <div className="w-px h-4 bg-slate-200 mx-0.5"></div>
                 <Button
@@ -151,9 +138,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                   aria-label="Cancel delete"
                   title="Cancel Delete"
                 >
-                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
-                    close
-                  </span>
+                  <span className="material-symbols-outlined text-[18px]" aria-hidden="true">close</span>
                 </Button>
               </div>
             ) : (
@@ -169,9 +154,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
                 title="Delete Resume"
                 aria-label="Delete Resume"
               >
-                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">
-                  delete
-                </span>
+                <span className="material-symbols-outlined text-[20px]" aria-hidden="true">delete</span>
               </Button>
             )}
           </div>
@@ -199,9 +182,7 @@ const ResumeCard: React.FC<ResumeCardProps> = ({
         {/* Footer with version count */}
         <div className="flex items-center justify-between pt-3 border-t border-slate-100">
           <div className="flex items-center gap-2 text-sm text-slate-500">
-            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">
-              history
-            </span>
+            <span className="material-symbols-outlined text-[16px]" aria-hidden="true">history</span>
             <span>
               {resume.versionCount} version{resume.versionCount !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to all 8 instances of `material-symbols-outlined` spans in the `ResumeCard` component.
🎯 Why: Material Symbols use font ligatures (like "share", "edit", "update"). Screen readers will often read these out loud. Because these icons are inside buttons with explicit `aria-label`s or next to visible text, reading the ligature text creates a redundant and confusing experience for screen reader users (e.g., reading "Edit Resume, edit, button"). Hiding the icon itself solves this.
📸 Before/After: Visuals are unchanged. Accessibility tree is cleaner.
♿ Accessibility: Significant improvement for screen reader users by removing noise from interactive elements.

---
*PR created automatically by Jules for task [7226964953815382799](https://jules.google.com/task/7226964953815382799) started by @anchapin*

## Summary by Sourcery

Improve accessibility of ResumeCard ligature icons by hiding decorative icon text from assistive technologies and documenting the pattern in the Palette log.

Bug Fixes:
- Prevent screen readers from announcing Material Symbols ligature text for ResumeCard icons by marking the icon spans as aria-hidden when labels or adjacent text already convey meaning.

Documentation:
- Extend the Palette accessibility log with guidance on using aria-hidden for Material Symbols ligature icons in ResumeCard and similar patterns.