### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in migration helpers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,9 @@
 **Vulnerability:** The `_get_table_row_count` method in `resume-api/lib/db/schema_manager.py` used a Python f-string within `sqlalchemy.text()` to build a SQL query dynamically (`text(f"SELECT COUNT(*) FROM {table_name}")`), creating a direct vector for SQL injection if `table_name` is user-controlled.
 **Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting (like f-strings or `.format()`). Using standard string concatenation in database execution is inherently dangerous.
 **Prevention:** To safely use dynamic identifiers (like table or column names), use SQLAlchemy core objects like `table()` or `column()` combined with `select()`. For dynamic values, use parameterized named bindings (e.g., `text('... WHERE col=:val'), {'val': var}`).
+
+## 2026-06-25 - [SQL Injection in BatchMigrationManager via text()]
+
+**Vulnerability:** The `migrate_table_in_batches` function in `resume-api/lib/db/migration_helpers.py` constructed SQL queries by interpolating user-controlled variables (`id_column` and `table_name`) into an f-string passed to SQLAlchemy's `text()` function. This enables severe SQL injection if the table name or ID column comes from untrusted input, allowing attackers to execute arbitrary SQL commands.
+**Learning:** `sqlalchemy.text()` does NOT sanitize variables passed into it via Python string formatting. Using f-strings inside `text()` bypasses parameterized query protections.
+**Prevention:** Always use SQLAlchemy's construct primitives (`table`, `column`, `select`) instead of raw SQL strings. This ensures identifiers are properly quoted and values are automatically parameterized.

--- a/resume-api/lib/db/migration_helpers.py
+++ b/resume-api/lib/db/migration_helpers.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Callable
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy import text
+from sqlalchemy import text, table, column, select
 
 logger = logging.getLogger(__name__)
 
@@ -312,12 +312,11 @@ class BatchMigrationManager:
             # Get batch of IDs
             async with self.primary_engine.begin() as conn:
                 result = await conn.execute(
-                    text(f"""
-                        SELECT {id_column} FROM {table_name}
-                        ORDER BY {id_column}
-                        LIMIT :limit OFFSET :offset
-                    """),
-                    {"limit": self.batch_size, "offset": offset},
+                    select(column(id_column))
+                    .select_from(table(table_name))
+                    .order_by(column(id_column))
+                    .limit(self.batch_size)
+                    .offset(offset)
                 )
                 rows = result.fetchall()
 


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The `migrate_table_in_batches` function in `resume-api/lib/db/migration_helpers.py` used string formatting (f-strings) inside SQLAlchemy's `text()` function to dynamically build a SQL query with `id_column` and `table_name`. This is a classic vector for SQL injection, allowing attackers to execute arbitrary SQL commands if the parameters were to come from an untrusted source.
**🎯 Impact:** A successful SQL injection attack via these parameters could allow an attacker to read, modify, or drop any tables in the database, leading to full data compromise and severe availability issues.
**🔧 Fix:** Refactored the raw SQL query to use proper SQLAlchemy core constructs (`select`, `table`, and `column`). This enforces correct quoting and automatically handles parameterization safely.
**✅ Verification:** 
1. The global linter (`pnpm lint`) passes (minus pre-existing unrelated warnings).
2. The python test suite (`pytest`) runs correctly without any new regressions.
3. Added a new journal entry to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [8158195174218734036](https://jules.google.com/task/8158195174218734036) started by @anchapin*

## Summary by Sourcery

Address a SQL injection vulnerability in batch migration helpers and update the security journal entry.

Bug Fixes:
- Eliminate SQL injection risk in `migrate_table_in_batches` by replacing raw interpolated SQL with safe SQLAlchemy core query construction.

Documentation:
- Add a Sentinel journal entry documenting the SQL injection vulnerability in `migrate_table_in_batches`, its impact, and the recommended secure patterns.